### PR TITLE
hooks: honor configured hooksPath

### DIFF
--- a/hooks/install-git-hooks.sh
+++ b/hooks/install-git-hooks.sh
@@ -1,39 +1,62 @@
 #!/bin/sh
-# Install Git hooks: symlink .git/hooks/* to SDP hooks.
-# Run from repo root (or from sdp/). Idempotent.
-# When sdp is submodule: .git/hooks/pre-commit -> sdp/hooks/pre-commit.sh
+# Install Git hooks into the path Git actually uses (.git/hooks or core.hooksPath).
 set -e
 
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-# Detect hooks source: sdp/hooks/ (when sdp submodule) or scripts/hooks/ (sdp_dev)
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
 if [ -d "$ROOT/sdp" ] && [ -f "$ROOT/sdp/hooks/pre-commit.sh" ]; then
   HOOKS_SRC="$ROOT/sdp/hooks"
-  REL_HOOKS="../../sdp/hooks"
 elif [ -f "$ROOT/scripts/hooks/pre-commit.sh" ]; then
   HOOKS_SRC="$ROOT/scripts/hooks"
-  REL_HOOKS="../../scripts/hooks"
 elif [ -f "$SCRIPT_DIR/pre-commit.sh" ]; then
   HOOKS_SRC="$SCRIPT_DIR"
-  REL_HOOKS="../../$(echo "$HOOKS_SRC" | sed "s|^$ROOT/||")"
 else
   echo "install-git-hooks: hooks not found (expected sdp/hooks/ or scripts/hooks/)" >&2
   exit 1
 fi
 
-HOOKS_DIR="$ROOT/.git/hooks"
+HOOKS_DIR="$(git rev-parse --git-path hooks)"
 mkdir -p "$HOOKS_DIR"
 
-if [ -f "$HOOKS_SRC/pre-commit.sh" ]; then
-  ln -sf "$REL_HOOKS/pre-commit.sh" "$HOOKS_DIR/pre-commit"
-  chmod +x "$HOOKS_SRC/pre-commit.sh"
-  echo "Installed pre-commit"
-fi
+install_hook() {
+  hook_name="$1"
+  source_path="$HOOKS_SRC/$hook_name.sh"
+  target_path="$HOOKS_DIR/$hook_name"
 
-if [ -f "$HOOKS_SRC/pre-push.sh" ]; then
-  ln -sf "$REL_HOOKS/pre-push.sh" "$HOOKS_DIR/pre-push"
-  chmod +x "$HOOKS_SRC/pre-push.sh"
-  echo "Installed pre-push"
-fi
+  if [ ! -f "$source_path" ]; then
+    return 0
+  fi
+
+  if [ -f "$target_path" ] && ! grep -q 'SDP-MANAGED-HOOK' "$target_path"; then
+    echo "Skipped $hook_name (existing hook is not SDP-managed)"
+    return 0
+  fi
+
+  tmp_path="$target_path.tmp.$$"
+  if grep -q 'SDP-MANAGED-HOOK' "$source_path"; then
+    cp "$source_path" "$tmp_path"
+  else
+    awk '
+      NR == 1 && $0 ~ /^#!/ {
+        print
+        print "# SDP-MANAGED-HOOK"
+        next
+      }
+      NR == 1 {
+        print "#!/bin/sh"
+        print "# SDP-MANAGED-HOOK"
+      }
+      { print }
+    ' "$source_path" > "$tmp_path"
+  fi
+
+  chmod +x "$tmp_path"
+  mv "$tmp_path" "$target_path"
+  echo "Installed $hook_name"
+}
+
+for hook_name in pre-commit pre-push post-checkout post-merge; do
+  install_hook "$hook_name"
+done

--- a/sdp-plugin/internal/hooks/hooks.go
+++ b/sdp-plugin/internal/hooks/hooks.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -42,12 +43,10 @@ func Install() error {
 
 // InstallWithOptions installs SDP-managed git hooks from the hooks/ directory.
 func InstallWithOptions(opts InstallOptions) error {
-	gitDir := ".git/hooks"
 	hookNames := hooksForOptions(opts)
-
-	// Check if .git exists
-	if _, err := os.Stat(".git"); os.IsNotExist(err) {
-		return fmt.Errorf(".git directory not found. Run 'git init' first")
+	repoRoot, gitDir, err := gitPaths()
+	if err != nil {
+		return err
 	}
 
 	// Create hooks directory if missing
@@ -57,7 +56,7 @@ func InstallWithOptions(opts InstallOptions) error {
 
 	// Try to find hooks source directory
 	// First check for local hooks/ directory (development)
-	hooksSourceDir := "hooks"
+	hooksSourceDir := filepath.Join(repoRoot, "hooks")
 	if _, err := os.Stat(hooksSourceDir); os.IsNotExist(err) {
 		// Fall back to embedded hooks
 		return installEmbeddedHooks(gitDir, hookNames)
@@ -178,7 +177,10 @@ func installEmbeddedHooks(gitDir string, hookNames []string) error {
 }
 
 func Uninstall() error {
-	gitDir := ".git/hooks"
+	_, gitDir, err := gitPaths()
+	if err != nil {
+		return err
+	}
 
 	for _, name := range allManagedHooks() {
 		path := filepath.Join(gitDir, name)
@@ -207,4 +209,35 @@ func Uninstall() error {
 	}
 
 	return nil
+}
+
+func gitPaths() (string, string, error) {
+	repoRootOut, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	if err != nil {
+		if _, statErr := os.Stat(".git"); statErr == nil {
+			return ".", filepath.Join(".git", "hooks"), nil
+		}
+		return "", "", fmt.Errorf(".git directory not found. Run 'git init' first")
+	}
+	repoRoot := strings.TrimSpace(string(repoRootOut))
+	if repoRoot == "" {
+		if _, statErr := os.Stat(".git"); statErr == nil {
+			return ".", filepath.Join(".git", "hooks"), nil
+		}
+		return "", "", fmt.Errorf(".git directory not found. Run 'git init' first")
+	}
+
+	hooksPathOut, err := exec.Command("git", "rev-parse", "--git-path", "hooks").CombinedOutput()
+	if err != nil {
+		return "", "", fmt.Errorf("resolve hooks path: %w", err)
+	}
+	hooksPath := strings.TrimSpace(string(hooksPathOut))
+	if hooksPath == "" {
+		return "", "", fmt.Errorf("resolve hooks path: empty result")
+	}
+	if !filepath.IsAbs(hooksPath) {
+		hooksPath = filepath.Join(repoRoot, hooksPath)
+	}
+
+	return repoRoot, hooksPath, nil
 }

--- a/sdp-plugin/internal/hooks/hooks_test.go
+++ b/sdp-plugin/internal/hooks/hooks_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -78,6 +79,37 @@ func TestInstallWithOptions_WithProvenance(t *testing.T) {
 		if !strings.Contains(string(content), sdpManagedMarker) {
 			t.Errorf("Hook %s missing marker", hookName)
 		}
+	}
+}
+
+func TestInstall_UsesConfiguredHooksPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoRoot := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	runGit(t, repoRoot, "init")
+	runGit(t, repoRoot, "config", "core.hooksPath", ".beads/hooks")
+
+	originalWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(originalWd) })
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	if err := Install(); err != nil {
+		t.Fatalf("Install() failed: %v", err)
+	}
+
+	for _, hookName := range []string{"pre-commit", "pre-push", "post-checkout", "post-merge"} {
+		hookPath := filepath.Join(repoRoot, ".beads", "hooks", hookName)
+		if _, err := os.Stat(hookPath); err != nil {
+			t.Fatalf("expected hook in configured hooksPath: %s (%v)", hookPath, err)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(repoRoot, ".git", "hooks", "pre-commit")); !os.IsNotExist(err) {
+		t.Fatalf("expected .git/hooks/pre-commit to stay untouched when core.hooksPath is set")
 	}
 }
 
@@ -689,6 +721,15 @@ func TestEnsureManagedMarker_InsertsAfterShebang(t *testing.T) {
 	}
 	if lines[1] != sdpManagedMarker {
 		t.Fatalf("marker not inserted after shebang: %q", out)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- install SDP-managed hooks into the actual Git hooks path instead of assuming `.git/hooks`
- keep embedded-hook behavior intact
- add test coverage for `core.hooksPath`

## Source
- extracted from #113 (`codex/beads-059-workflow-drift`)
- split out so the useful hooks fix is not blocked by beads/runtime noise in the old branch

## Verification
- `cd sdp-plugin && go test ./internal/hooks`
- `cd sdp-plugin && go vet ./internal/hooks ./cmd/sdp`
- `cd sdp-plugin && go build ./cmd/sdp`