### PR TITLE
beads: tolerate missing local database in ready

### DIFF
--- a/sdp-plugin/internal/beads/client.go
+++ b/sdp-plugin/internal/beads/client.go
@@ -3,6 +3,7 @@ package beads
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -51,6 +52,9 @@ func (c *Client) Ready() ([]Task, error) {
 
 	output, err := c.runBeadsCommand("ready")
 	if err != nil {
+		if errors.Is(err, ErrNoBeadsDatabase) {
+			return []Task{}, nil
+		}
 		return []Task{}, fmt.Errorf("bd ready failed: %w", err)
 	}
 

--- a/sdp-plugin/internal/beads/client_with_beads_test.go
+++ b/sdp-plugin/internal/beads/client_with_beads_test.go
@@ -321,6 +321,39 @@ fi
 	}
 }
 
+func TestReadyWithoutDatabaseReturnsEmptySlice(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	bdScript := `#!/bin/bash
+if [ "$1" = "ready" ]; then
+	echo "Error: no beads database found" >&2
+	echo "Hint: run 'bd init' to create a database in the current directory" >&2
+	exit 1
+fi
+`
+	bdPath := filepath.Join(tmpDir, "bd")
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatalf("Failed to create fake bd: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Cleanup(func() { os.Setenv("PATH", oldPath) })
+	os.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath)
+
+	client, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	tasks, err := client.Ready()
+	if err != nil {
+		t.Fatalf("Ready() should treat missing database as empty, got: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("Expected 0 tasks, got %d", len(tasks))
+	}
+}
+
 // TestNewClientWithFakeBeads tests NewClient detects fake beads
 func TestNewClientWithFakeBeads(t *testing.T) {
 	// Create a temporary directory with a fake "bd" binary

--- a/sdp-plugin/internal/beads/utils.go
+++ b/sdp-plugin/internal/beads/utils.go
@@ -1,16 +1,27 @@
 package beads
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
+
+var ErrNoBeadsDatabase = errors.New("no beads database found")
 
 // runBeadsCommand executes a Beads CLI command
 func (c *Client) runBeadsCommand(args ...string) (string, error) {
 	cmd := exec.Command("bd", args...)
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
+		trimmed := strings.TrimSpace(string(output))
+		if strings.Contains(trimmed, "no beads database found") {
+			return "", fmt.Errorf("%w: %s", ErrNoBeadsDatabase, trimmed)
+		}
+		if trimmed != "" {
+			return "", fmt.Errorf("command failed: %s: %w", trimmed, err)
+		}
 		return "", fmt.Errorf("command failed: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- treat missing local beads database as an empty ready queue instead of a hard error
- harden the client test surface for current beads CLI behavior

## Source
- extracted from #112 (`codex/reality-oss-pr`)
- intended as a standalone fix instead of leaving it buried inside the old reality PR

## Verification
- `cd sdp-plugin && go test ./internal/beads`
- `cd sdp-plugin && go vet ./internal/beads ./cmd/sdp`
- `cd sdp-plugin && go build ./cmd/sdp`