### PR TITLE
feat(F099): Brownfield Safe Overlay — install, uninstall, adoption guide

### DIFF
--- a/docs/ADOPTION.md
+++ b/docs/ADOPTION.md
@@ -1,0 +1,299 @@
+# SDP Adoption Guide — Brownfield Projects
+
+> Use this guide when adding SDP to an existing project. If you are starting a new project, start with [QUICKSTART.md](QUICKSTART.md) instead.
+
+SDP is designed to layer onto existing work without disrupting it. This guide walks through the safe adoption path: assess first, try on a branch, then adopt when ready.
+
+## Install Method Decision Matrix
+
+Choose your install method based on your situation:
+
+| Method | When to use | What it does | Risk level |
+|--------|-------------|--------------|------------|
+| `sdp assess` | You want to see what SDP would change before touching anything | Read-only scan of your repo. Produces a report. No files modified. | None |
+| `sdp try "task"` | You want to test SDP on real work in isolation | Creates a temporary branch, runs the task, shows results. Branch is disposable. | Minimal |
+| `install.sh` (project mode) | You are ready to install SDP prompts and hooks into your repo | Installs prompts, hooks, config into your project. Backs up existing files. | Low (backup + preview) |
+| `install.sh --binary-only` | You want the CLI without touching project files | Installs `sdp` binary to `~/.local/bin/`. No project changes. | None |
+| `git submodule add` | You want SDP vendored and version-locked inside your repo | Adds `sdp/` as a git submodule. Full control over updates. | Low |
+
+### Environment Variables
+
+The installer respects these environment variables:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SDP_IDE` | `auto` | Force a specific IDE: `claude`, `cursor`, `opencode`, `codex` |
+| `SDP_DIR` | `sdp` | Change the SDP checkout directory name |
+| `SDP_REF` | `main` | Install from a specific branch or tag |
+| `SDP_REPO` | `fall-out-bug/sdp` | Install from a fork |
+
+## Step 1: Assess Your Project
+
+Before installing anything, run a read-only assessment:
+
+```bash
+sdp assess
+```
+
+Or point it at a specific path:
+
+```bash
+sdp assess /path/to/project
+```
+
+**What it does:**
+
+- Scans your repo structure, languages, and tooling
+- Reports which SDP surfaces would activate (skills, agents, hooks)
+- Identifies potential conflicts with existing IDE config
+- Suggests the best install method for your setup
+- Writes nothing to disk
+
+**Typical output includes:**
+
+```
+Project: my-app (Go + TypeScript)
+Detected IDEs: Claude Code, Cursor
+Recommended install: project mode (install.sh)
+
+Conflicts:
+  .claude/settings.json — will be merged, not overwritten
+
+Suggested next step:
+  sdp try "Add a health endpoint"
+```
+
+If `sdp` is not installed yet, use the binary-only install first:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/fall-out-bug/sdp/main/install.sh | sh -s -- --binary-only
+```
+
+## Step 2: Try SDP on a Disposable Task
+
+When the assessment looks good, test SDP on real work without committing to it:
+
+```bash
+sdp try "Add a health check endpoint"
+```
+
+**What it does:**
+
+1. Creates a temporary branch (`sdp-try-<timestamp>`)
+2. Initializes SDP config on that branch
+3. Runs the task using SDP skills and agents
+4. Shows the result: what changed, evidence produced, quality gates passed
+5. Leaves you on the branch so you can inspect the result
+
+**You control what happens next:**
+
+```bash
+# Inspect the changes
+git diff main
+
+# Keep the work if you like it
+git checkout main
+git merge sdp-try-<timestamp>
+
+# Or discard it entirely
+git checkout main
+git branch -D sdp-try-<timestamp>
+```
+
+**Key flags:**
+
+| Flag | Behavior |
+|------|----------|
+| `sdp try "task"` | Interactive: shows progress, asks before finalizing |
+| `sdp try "task" --auto` | Fully automated: runs end to end without prompts |
+
+## Step 3: Install SDP Into Your Project
+
+Once you have tried SDP and want to keep it:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/fall-out-bug/sdp/main/install.sh | sh
+```
+
+### Preview Before Applying
+
+Always preview first:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/fall-out-bug/sdp/main/install.sh | sh -s -- --preview
+```
+
+Preview mode shows every file that would be created, modified, or merged, without writing anything.
+
+### What Gets Installed
+
+The installer adds these to your project:
+
+1. **`sdp/`** — SDP checkout (can be a git submodule or shallow clone)
+2. **IDE adapters** — symlinks in `.claude/`, `.cursor/`, `.opencode/`, or `.codex/` pointing to prompts and agents
+3. **`settings.json` merge** — SDP hooks are merged into your existing IDE settings. Your existing keys are preserved.
+4. **Git hooks** — `pre-commit` and `pre-push` hooks (if not already present)
+5. **`.gitignore` entries** — SDP-managed paths are added
+
+### How Existing Config Is Protected
+
+The installer never overwrites your existing config without consent:
+
+- **Backup:** Before any modification, the original file is copied to `.sdp/backup/` with a timestamp.
+- **Merge, not overwrite:** If `.claude/settings.json` already exists, SDP hooks are appended to arrays using `jq` deep merge. Your existing keys, hooks, and settings are untouched.
+- **No `jq` installed?** The installer preserves your existing settings entirely and prints instructions for manual merge.
+- **`--no-overwrite-config` flag:** Skip config file changes altogether. Prompts and agents still install.
+
+### IDE Detection
+
+The installer auto-detects which IDE you use by checking for `.claude/`, `.cursor/`, `.opencode/`, and `.codex/` directories, plus PATH entries for `claude`, `cursor`, `opencode`, `windsurf`, and `codex`.
+
+Override detection with:
+
+```bash
+SDP_IDE=claude curl -sSL https://raw.githubusercontent.com/fall-out-bug/sdp/main/install.sh | sh
+```
+
+## Step 4: Transition to Full SDP
+
+After installing, SDP runs in **adoption mode** by default. Quality gates (file size limits, coverage thresholds, TDD enforcement) are disabled. Evidence logging stays active but is non-blocking.
+
+### Adoption Mode
+
+```bash
+sdp init --auto
+```
+
+This creates `.sdp/config.yml` with `adoption_mode: true`. In this mode:
+
+- `@build` and `@oneshot` execute without quality gate failures on legacy code
+- Evidence events are still logged to `.sdp/log/events.jsonl`
+- `sdp doctor` shows the current adoption mode
+
+### Enable Full Gates
+
+When your project is ready for full SDP enforcement:
+
+```bash
+sdp adopt --full
+```
+
+This sets `adoption_mode: false` in `.sdp/config.yml` and enables all quality gates:
+
+- File size limits
+- Test coverage thresholds
+- TDD enforcement (test-first)
+- Full evidence validation
+
+**When to enable full gates:** after your project has passing tests, the codebase structure is stable, and you have at least one successful SDP feature delivery in adoption mode.
+
+### Verify Your Setup
+
+```bash
+sdp doctor
+```
+
+`doctor` checks your environment and reports:
+
+- Git status
+- SDP CLI version
+- IDE integration status
+- Config file health
+- Adoption mode (on or off)
+
+## Step 5: Uninstall SDP
+
+SDP can be removed cleanly. User data is preserved by default.
+
+### Standard Uninstall
+
+Removes SDP artifacts (symlinks, hooks, gitignore entries) while preserving your config and the SDP checkout:
+
+```bash
+sh sdp/scripts/uninstall.sh
+```
+
+**What is removed:**
+
+- Symlinks in `.claude/skills`, `.claude/agents`, `.cursor/skills`, `.cursor/agents`, `.opencode/skills`, `.opencode/agents`, `.codex/skills/sdp`, `.codex/agents`
+- SDP-installed files: `.claude/commands.json`, `.codex/INSTALL.md`, `.codex/skills/README.md`
+- Git hooks pointing to SDP (`pre-commit`, `pre-push`)
+- SDP entries from `.gitignore`
+
+**What is preserved:**
+
+- `.claude/settings.json` (your IDE settings, including non-SDP keys)
+- `.sdp/` directory (project config and backups)
+- `sdp/` checkout directory
+
+### Dry Run
+
+See what would be removed without removing anything:
+
+```bash
+sh sdp/scripts/uninstall.sh --dry-run
+```
+
+### Purge Everything
+
+Remove all SDP-related files, including the checkout, backups, and config:
+
+```bash
+sh sdp/scripts/uninstall.sh --purge
+```
+
+Even in purge mode, `.claude/settings.json` is preserved because it likely contains your own customizations beyond SDP.
+
+Skip the confirmation prompt:
+
+```bash
+sh sdp/scripts/uninstall.sh --purge -y
+```
+
+### Reinstall After Uninstall
+
+```bash
+sh sdp/scripts/install-project.sh
+```
+
+Or from remote:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/fall-out-bug/sdp/main/install.sh | sh
+```
+
+## Quick Reference
+
+```bash
+# Assess before installing
+sdp assess
+
+# Try a task in isolation
+sdp try "Add a health endpoint"
+
+# Install (preview first)
+curl -sSL https://raw.githubusercontent.com/fall-out-bug/sdp/main/install.sh | sh -s -- --preview
+curl -sSL https://raw.githubusercontent.com/fall-out-bug/sdp/main/install.sh | sh
+
+# Verify setup
+sdp doctor
+
+# Enable full quality gates
+sdp adopt --full
+
+# Uninstall (dry run first)
+sh sdp/scripts/uninstall.sh --dry-run
+sh sdp/scripts/uninstall.sh
+
+# Full purge
+sh sdp/scripts/uninstall.sh --purge
+```
+
+## Related Documentation
+
+| Document | Content |
+|----------|---------|
+| [QUICKSTART.md](QUICKSTART.md) | 5-minute guide for new projects |
+| [CLI_REFERENCE.md](CLI_REFERENCE.md) | Full command reference |
+| [PROTOCOL.md](PROTOCOL.md) | Protocol overview |
+| [PRODUCT_CONTRACT.md](PRODUCT_CONTRACT.md) | Product definition and mode policy |

--- a/docs/ADOPTION.md
+++ b/docs/ADOPTION.md
@@ -2,6 +2,9 @@
 
 > Use this guide when adding SDP to an existing project. If you are starting a new project, start with [QUICKSTART.md](QUICKSTART.md) instead.
 
+> **Note:** This guide describes the planned SDP CLI experience. Commands and flags are
+> specification-level and will be verified against implementation as features land.
+
 SDP is designed to layer onto existing work without disrupting it. This guide walks through the safe adoption path: assess first, try on a branch, then adopt when ready.
 
 ## Install Method Decision Matrix
@@ -15,6 +18,8 @@ Choose your install method based on your situation:
 | `install.sh` (project mode) | You are ready to install SDP prompts and hooks into your repo | Installs prompts, hooks, config into your project. Backs up existing files. | Low (backup + preview) |
 | `install.sh --binary-only` | You want the CLI without touching project files | Installs `sdp` binary to `~/.local/bin/`. No project changes. | None |
 | `git submodule add` | You want SDP vendored and version-locked inside your repo | Adds `sdp/` as a git submodule. Full control over updates. | Low |
+
+> All methods install the `sdp` command-line binary. Package names differ by registry.
 
 ### Environment Variables
 
@@ -169,6 +174,8 @@ This creates `.sdp/config.yml` with `adoption_mode: true`. In this mode:
 - `@build` and `@oneshot` execute without quality gate failures on legacy code
 - Evidence events are still logged to `.sdp/log/events.jsonl`
 - `sdp doctor` shows the current adoption mode
+
+> **Tip:** For monorepo setups, see [FAQ: Does SDP work with monorepos?](#6-faq)
 
 ### Enable Full Gates
 

--- a/install.sh
+++ b/install.sh
@@ -4,9 +4,11 @@
 # Usage:
 #   curl -sSL https://raw.githubusercontent.com/fall-out-bug/sdp/main/install.sh | sh
 #   curl -sSL https://raw.githubusercontent.com/fall-out-bug/sdp/main/install.sh | sh -s -- --binary-only
+#   curl -sSL https://raw.githubusercontent.com/fall-out-bug/sdp/main/install.sh | sh -s -- --preview
 #
 # Default: project assets (prompts/hooks/config)
-# --binary-only: install global CLI binary only
+# --binary-only:  install global CLI binary only
+# --preview:      show what would change without applying it
 
 set -e
 

--- a/scripts/install-project.sh
+++ b/scripts/install-project.sh
@@ -54,7 +54,8 @@ fi
 init_backup_dir() {
     # Called before cd into $SDP_DIR. At this point cwd is the project root.
     project_root="$(pwd)"
-    SDP_BACKUP_DIR="$project_root/.sdp/backup/$(date +%Y%m%dT%H%M%S)-$$_${RANDOM:-0}"
+    _rand=${RANDOM:-$(od -An -N2 -tu2 /dev/urandom 2>/dev/null | tr -d ' ')}
+    SDP_BACKUP_DIR="$project_root/.sdp/backup/$(date +%Y%m%dT%H%M%S)-$$_${_rand:-0}"
 }
 
 backup_file() {
@@ -156,6 +157,20 @@ merge_settings_json() {
 
     # Extract existing dest content
     dest_content=$(cat "$dest")
+
+    # Guard: skip merge if dest is empty or not valid JSON
+    if [ -z "$dest_content" ] || ! printf '%s' "$dest_content" | jq -e . >/dev/null 2>&1; then
+        echo "  Note: $dest is empty or invalid JSON — replacing with SDP defaults."
+        if [ "$SDP_PREVIEW" = "1" ]; then
+            preview_note "REPLACE (invalid JSON)" "$dest"
+            return
+        fi
+        backup_file "$dest"
+        mkdir -p "$(dirname "$dest")"
+        cp "$src" "$dest"
+        return
+    fi
+
     src_content=$(cat "$src")
 
     # Check if jq is available for proper merge

--- a/scripts/install-project.sh
+++ b/scripts/install-project.sh
@@ -3,6 +3,11 @@
 #
 # Installs prompts/hooks config into the current project.
 # This script does NOT require installing the SDP CLI binary.
+#
+# Flags:
+#   --preview             Show what would change without modifying anything.
+#   --no-overwrite-config Preserve existing IDE config files (legacy, default behavior).
+#   --overwrite-config    Overwrite existing config files (not recommended).
 
 set -eu
 
@@ -16,6 +21,9 @@ SDP_PRESERVE_CONFIG="${SDP_PRESERVE_CONFIG:-0}"
 DEFAULT_REMOTE="https://github.com/fall-out-bug/sdp.git"
 SDP_AUTO_FALLBACK_ALL=0
 SDP_CONFIGURED_INTEGRATIONS=""
+SDP_PREVIEW=0
+SDP_BACKUP_DIR=""
+SDP_PREVIEW_CHANGES=""
 
 for arg in "$@"; do
     case "$arg" in
@@ -25,14 +33,206 @@ for arg in "$@"; do
         --overwrite-config)
             SDP_PRESERVE_CONFIG="0"
             ;;
+        --preview)
+            SDP_PREVIEW=1
+            ;;
     esac
 done
 
-echo "🚀 SDP Project Installer"
+echo "SDP Project Installer"
 echo "========================"
-if [ "$SDP_PRESERVE_CONFIG" = "1" ]; then
+if [ "$SDP_PREVIEW" = "1" ]; then
+    echo "Mode: PREVIEW (no changes will be made)"
+elif [ "$SDP_PRESERVE_CONFIG" = "1" ]; then
     echo "Mode: preserve existing IDE config files"
 fi
+
+# ---------------------------------------------------------------------------
+# Backup helpers
+# ---------------------------------------------------------------------------
+
+init_backup_dir() {
+    # Called before cd into $SDP_DIR. At this point cwd is the project root.
+    project_root="$(pwd)"
+    SDP_BACKUP_DIR="$project_root/.sdp/backup/$(date +%Y%m%dT%H%M%S)"
+}
+
+backup_file() {
+    file="$1"
+    if [ ! -e "$file" ]; then
+        return
+    fi
+    mkdir -p "$SDP_BACKUP_DIR"
+    # Normalize path: strip leading ../ to get a clean relative path
+    clean_path=$(echo "$file" | sed 's|^\.\./||')
+    dest_dir="$SDP_BACKUP_DIR/$(dirname "$clean_path")"
+    mkdir -p "$dest_dir"
+    cp "$file" "$dest_dir/$(basename "$file")"
+}
+
+# ---------------------------------------------------------------------------
+# Preview helpers
+# ---------------------------------------------------------------------------
+
+preview_note() {
+    action="$1"
+    target="$2"
+    if [ "$SDP_PREVIEW" = "1" ]; then
+        SDP_PREVIEW_CHANGES="$SDP_PREVIEW_CHANGES
+  $action: $target"
+        return 0
+    fi
+    return 1
+}
+
+preview_link() {
+    target="$1"
+    dest="$2"
+    if preview_note "CREATE symlink" "$dest -> $target"; then
+        return
+    fi
+    mkdir -p "$(dirname "$dest")"
+    ln -sfn "$target" "$dest"
+}
+
+preview_tree() {
+    src_dir="$1"
+    dest_dir="$2"
+    if [ ! -d "$src_dir" ]; then
+        return
+    fi
+    find "$src_dir" -type f | while IFS= read -r src; do
+        rel="${src#$src_dir/}"
+        preview_file "$src" "$dest_dir/$rel"
+    done
+}
+
+preview_file() {
+    src="$1"
+    dest="$2"
+
+    # Backup before overwrite
+    if [ "$SDP_PREVIEW" = "0" ] && [ -e "$dest" ]; then
+        backup_file "$dest"
+    fi
+
+    if preview_note "COPY" "$dest"; then
+        return
+    fi
+
+    mkdir -p "$(dirname "$dest")"
+    cp "$src" "$dest"
+}
+
+# ---------------------------------------------------------------------------
+# JSON merge for settings.json (POSIX-compatible, no jq dependency)
+# Merges SDP hook entries into existing settings.json arrays.
+# Preserves all user-existing keys unchanged.
+# ---------------------------------------------------------------------------
+
+merge_settings_json() {
+    src="$1"
+    dest="$2"
+    backup_path="$SDP_BACKUP_DIR"
+
+    # If dest does not exist, simple copy
+    if [ ! -f "$dest" ]; then
+        if preview_note "CREATE" "$dest"; then
+            return
+        fi
+        mkdir -p "$(dirname "$dest")"
+        cp "$src" "$dest"
+        return
+    fi
+
+    # Backup existing file
+    if [ "$SDP_PREVIEW" = "0" ]; then
+        backup_file "$dest"
+    fi
+
+    # Parse the source SDP settings to extract keys
+    # We use a simple approach: for each top-level key in src,
+    # if dest has it and it's an object/array, merge; otherwise set from src.
+
+    # Extract existing dest content
+    dest_content=$(cat "$dest")
+    src_content=$(cat "$src")
+
+    # Check if jq is available for proper merge
+    if command -v jq >/dev/null 2>&1; then
+        # Proper deep merge with jq:
+        # - For arrays under "hooks.*", append new entries (avoiding duplicates)
+        # - For objects, merge recursively
+        # - For scalars, take the source value only if missing from dest
+
+        merged=$(printf '%s\n%s\n' "$dest_content" "$src_content" | jq -n '
+            # inputs: [dest, src]
+            # Deep merge: dest as base, overlay src.
+            # Arrays: concatenate and deduplicate (by value equality).
+            # Objects: recurse. Scalars: src wins (only when key is new or src differs).
+            [inputs] as $docs |
+            $docs[0] as $dest |
+            $docs[1] as $src |
+
+            def deepmerge(a; b):
+              if (a | type) == "object" and (b | type) == "object" then
+                (a + b) | to_entries | map(
+                  .key as $k |
+                  if ($k | in(a)) == false then .
+                  elif ($k | in(b)) == false then .key as $kk | {key: $kk, value: a[$kk]}
+                  elif (a[$k] | type) == "object" and (b[$k] | type) == "object" then
+                    {key: $k, value: (deepmerge(a[$k]; b[$k]))}
+                  elif (a[$k] | type) == "array" and (b[$k] | type) == "array" then
+                    {key: $k, value: (a[$k] + b[$k] | unique)}
+                  else
+                    {key: $k, value: b[$k]}
+                  end
+                ) | from_entries
+              elif (a | type) == "array" and (b | type) == "array" then
+                a + b | unique
+              else
+                b
+              end;
+
+            deepmerge($dest; $src)
+        ')
+
+        if [ "$SDP_PREVIEW" = "1" ]; then
+            preview_note "MERGE (jq)" "$dest"
+            SDP_PREVIEW_CHANGES="$SDP_PREVIEW_CHANGES
+    Merged content preview:
+$(echo "$merged" | head -20)"
+        else
+            echo "$merged" > "$dest"
+        fi
+    else
+        # No jq: fall back to preserving existing file entirely.
+        # Only copy if dest doesn't already have SDP markers.
+        if printf '%s' "$dest_content" | grep -q '"hooks"'; then
+            # Dest already has hooks — preserve it, log a warning
+            if [ "$SDP_PREVIEW" = "1" ]; then
+                preview_note "SKIP (existing hooks preserved, install jq for proper merge)" "$dest"
+            else
+                echo "  Note: $dest already has hooks config. Install jq for automatic merge."
+                echo "  Existing file preserved. SDP settings available at: $src"
+            fi
+        else
+            # Dest has no hooks — safe to append SDP content
+            # Simple append approach: take everything from src that's missing
+            if [ "$SDP_PREVIEW" = "1" ]; then
+                preview_note "MERGE (basic, no jq)" "$dest"
+            else
+                # Use the source file (dest had no hooks), but keep user keys
+                # Very basic: just overwrite. User was told to install jq.
+                cp "$src" "$dest"
+            fi
+        fi
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# IDE detection
+# ---------------------------------------------------------------------------
 
 detect_auto_ide() {
     detected=""
@@ -95,6 +295,10 @@ print_configured_integrations() {
     done
 }
 
+# ---------------------------------------------------------------------------
+# File sync (with backup and merge awareness)
+# ---------------------------------------------------------------------------
+
 sync_file() {
     src="$1"
     dest="$2"
@@ -103,8 +307,7 @@ sync_file() {
         return
     fi
 
-    mkdir -p "$(dirname "$dest")"
-    cp "$src" "$dest"
+    preview_file "$src" "$dest"
 }
 
 sync_tree_files() {
@@ -129,9 +332,12 @@ sync_link() {
         return
     fi
 
-    mkdir -p "$(dirname "$dest")"
-    ln -sfn "$target" "$dest"
+    preview_link "$target" "$dest"
 }
+
+# ---------------------------------------------------------------------------
+# Managed checkout helpers
+# ---------------------------------------------------------------------------
 
 ensure_managed_checkout() {
     if ! git -C "$SDP_DIR" rev-parse --git-dir >/dev/null 2>&1; then
@@ -151,7 +357,7 @@ ensure_clean_checkout() {
 }
 
 update_existing_checkout() {
-    echo "⚠️  $SDP_DIR already exists. Updating..."
+    echo "Warning: $SDP_DIR already exists. Updating..."
     ensure_managed_checkout
     ensure_clean_checkout
 
@@ -165,54 +371,76 @@ update_existing_checkout() {
     git -C "$SDP_DIR" checkout -B "$SDP_REF" FETCH_HEAD >/dev/null 2>&1
 }
 
-# Check if already installed
-if [ -d "$SDP_DIR" ]; then
-    update_existing_checkout
+# ---------------------------------------------------------------------------
+# Initialize backup directory (before any modifications)
+# ---------------------------------------------------------------------------
+
+init_backup_dir
+
+# ---------------------------------------------------------------------------
+# Clone or update SDP checkout
+# ---------------------------------------------------------------------------
+
+if [ "$SDP_PREVIEW" = "1" ]; then
+    if [ -d "$SDP_DIR" ]; then
+        SDP_PREVIEW_CHANGES="$SDP_PREVIEW_CHANGES
+  UPDATE: $SDP_DIR (existing checkout)"
+    else
+        SDP_PREVIEW_CHANGES="$SDP_PREVIEW_CHANGES
+  CLONE: $SDP_DIR from $REMOTE ($SDP_REF)"
+    fi
 else
-    echo "📦 Cloning SDP (ref: $SDP_REF)..."
-    git clone --depth 1 -b "$SDP_REF" "$REMOTE" "$SDP_DIR" 2>/dev/null || git clone --depth 1 "$REMOTE" "$SDP_DIR"
+    if [ -d "$SDP_DIR" ]; then
+        update_existing_checkout
+    else
+        echo "Cloning SDP (ref: $SDP_REF)..."
+        git clone --depth 1 -b "$SDP_REF" "$REMOTE" "$SDP_DIR" 2>/dev/null || git clone --depth 1 "$REMOTE" "$SDP_DIR"
+    fi
 fi
 
 cd "$SDP_DIR"
 
+# ---------------------------------------------------------------------------
 # Optional CLI install for project mode
-if [ "$SDP_INSTALL_CLI" = "1" ]; then
+# ---------------------------------------------------------------------------
+
+if [ "$SDP_INSTALL_CLI" = "1" ] && [ "$SDP_PREVIEW" = "0" ]; then
     cli_installed=0
 
     if [ "$REMOTE" = "$DEFAULT_REMOTE" ]; then
-        echo "🔧 Installing SDP CLI binary from latest release..."
+        echo "Installing SDP CLI binary from latest release..."
         if sh scripts/install.sh latest; then
             cli_installed=1
         else
-            echo "⚠️  Release binary installation failed."
+            echo "Warning: Release binary installation failed."
             if [ "$SDP_INSTALL_CLI_FROM_SOURCE" = "1" ] && command -v go >/dev/null 2>&1; then
-                echo "🔧 Trying source build fallback..."
+                echo "Trying source build fallback..."
                 mkdir -p "${HOME}/.local/bin"
                 if (
                     cd sdp-plugin && \
                     CGO_ENABLED=0 GOFLAGS=-buildvcs=false go build -o "${HOME}/.local/bin/sdp" ./cmd/sdp
                 ); then
-                    echo "✅ Installed CLI from source to ${HOME}/.local/bin/sdp"
+                    echo "  Installed CLI from source to ${HOME}/.local/bin/sdp"
                     cli_installed=1
                 fi
             fi
         fi
     else
         if command -v go >/dev/null 2>&1; then
-            echo "🔧 Building SDP CLI from checked-out source (custom remote)..."
+            echo "Building SDP CLI from checked-out source (custom remote)..."
             mkdir -p "${HOME}/.local/bin"
             if (
                 cd sdp-plugin && \
                 CGO_ENABLED=0 GOFLAGS=-buildvcs=false go build -o "${HOME}/.local/bin/sdp" ./cmd/sdp
             ); then
-                echo "✅ Installed CLI from source to ${HOME}/.local/bin/sdp"
+                echo "  Installed CLI from source to ${HOME}/.local/bin/sdp"
                 cli_installed=1
             fi
         fi
     fi
 
     if [ "$cli_installed" != "1" ]; then
-        echo "⚠️  CLI installation failed. Prompts are installed, but 'sdp init' may not be available yet."
+        echo "Warning: CLI installation failed. Prompts are installed, but 'sdp init' may not be available yet."
         if [ "$REMOTE" = "$DEFAULT_REMOTE" ]; then
             echo ""
             echo "   Retry CLI install:"
@@ -221,23 +449,29 @@ if [ "$SDP_INSTALL_CLI" = "1" ]; then
             echo "   Retry: install Go, then run 'cd sdp/sdp-plugin && go build -o \${HOME}/.local/bin/sdp ./cmd/sdp'"
         fi
     fi
+elif [ "$SDP_INSTALL_CLI" = "1" ] && [ "$SDP_PREVIEW" = "1" ]; then
+    SDP_PREVIEW_CHANGES="$SDP_PREVIEW_CHANGES
+  INSTALL CLI: sdp binary to ${HOME}/.local/bin/"
 fi
 
+# ---------------------------------------------------------------------------
 # Setup for selected IDE
+# ---------------------------------------------------------------------------
+
 if [ "$SDP_IDE" = "auto" ]; then
     if SDP_IDE_LIST=$(detect_auto_ide); then
-        echo "🔗 Setting up for auto-detected IDEs: $SDP_IDE_LIST"
+        echo "Setting up for auto-detected IDEs: $SDP_IDE_LIST"
     else
         status=$?
         if [ "$status" -ne 10 ]; then
             exit "$status"
         fi
         SDP_AUTO_FALLBACK_ALL=1
-        echo "🔗 Setting up for all supported IDEs: $SDP_IDE_LIST"
+        echo "Setting up for all supported IDEs: $SDP_IDE_LIST"
     fi
 else
     SDP_IDE_LIST="$SDP_IDE"
-    echo "🔗 Setting up for: $SDP_IDE"
+    echo "Setting up for: $SDP_IDE"
 fi
 
 setup_claude() {
@@ -247,7 +481,8 @@ setup_claude() {
     sync_file .claude/commands.json ../.claude/commands.json
     sync_tree_files .claude/hooks ../.claude/hooks
     sync_tree_files .claude/patterns ../.claude/patterns
-    sync_file .claude/settings.json ../.claude/settings.json
+    # Merge settings.json instead of overwriting
+    merge_settings_json .claude/settings.json ../.claude/settings.json
     register_integration "Claude" ".claude/"
 }
 
@@ -299,40 +534,84 @@ for ide in $SDP_IDE_LIST; do
             setup_codex
             ;;
         *)
-            echo "⚠️  Unknown SDP_IDE value '$ide', skipping"
+            echo "  Warning: Unknown SDP_IDE value '$ide', skipping"
             ;;
     esac
 done
 
-# Add to .gitignore
+# ---------------------------------------------------------------------------
+# .gitignore entries
+# ---------------------------------------------------------------------------
+
 if [ -f ../.gitignore ]; then
     if ! grep -q "$SDP_DIR/.git" ../.gitignore; then
-        echo "" >> ../.gitignore
-        echo "# SDP" >> ../.gitignore
-        echo "$SDP_DIR/.git" >> ../.gitignore
-        echo ".claude/skills" >> ../.gitignore
-        echo ".claude/agents" >> ../.gitignore
-        echo ".cursor/skills" >> ../.gitignore
-        echo ".cursor/agents" >> ../.gitignore
-        echo ".opencode/skills" >> ../.gitignore
-        echo ".opencode/agents" >> ../.gitignore
-        echo ".codex/skills/sdp" >> ../.gitignore
-        echo ".codex/agents" >> ../.gitignore
-        echo ".prompts" >> ../.gitignore
-        echo "✅ Added entries to .gitignore"
+        if [ "$SDP_PREVIEW" = "1" ]; then
+            SDP_PREVIEW_CHANGES="$SDP_PREVIEW_CHANGES
+  APPEND: .gitignore (SDP entries)"
+        else
+            echo "" >> ../.gitignore
+            echo "# SDP" >> ../.gitignore
+            echo "$SDP_DIR/.git" >> ../.gitignore
+            echo ".claude/skills" >> ../.gitignore
+            echo ".claude/agents" >> ../.gitignore
+            echo ".cursor/skills" >> ../.gitignore
+            echo ".cursor/agents" >> ../.gitignore
+            echo ".opencode/skills" >> ../.gitignore
+            echo ".opencode/agents" >> ../.gitignore
+            echo ".codex/skills/sdp" >> ../.gitignore
+            echo ".codex/agents" >> ../.gitignore
+            echo ".prompts" >> ../.gitignore
+            echo "  Added entries to .gitignore"
+        fi
     fi
 fi
 
-# Install Git hooks (pre-commit, pre-push)
+# ---------------------------------------------------------------------------
+# Git hooks
+# ---------------------------------------------------------------------------
+
 if [ -f hooks/install-git-hooks.sh ]; then
-    if (cd .. && sh "$SDP_DIR/hooks/install-git-hooks.sh" 2>/dev/null); then
-        echo "✅ Git hooks installed (pre-commit, pre-push)"
+    if [ "$SDP_PREVIEW" = "1" ]; then
+        SDP_PREVIEW_CHANGES="$SDP_PREVIEW_CHANGES
+  INSTALL: git hooks (pre-commit, pre-push)"
+    else
+        if (cd .. && sh "$SDP_DIR/hooks/install-git-hooks.sh" 2>/dev/null); then
+            echo "  Git hooks installed (pre-commit, pre-push)"
+        fi
     fi
 fi
 
+# ---------------------------------------------------------------------------
+# Preview summary
+# ---------------------------------------------------------------------------
+
+if [ "$SDP_PREVIEW" = "1" ]; then
+    echo ""
+    echo "=== PREVIEW: Changes that would be made ==="
+    if [ -n "$SDP_PREVIEW_CHANGES" ]; then
+        echo "$SDP_PREVIEW_CHANGES" | grep -v '^$' | sed 's/^/  /'
+    else
+        echo "  (no changes)"
+    fi
+    echo ""
+    echo "Run without --preview to apply these changes."
+    echo "Existing configs will be backed up to .sdp/backup/ before modification."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Final summary
+# ---------------------------------------------------------------------------
+
 echo ""
-echo "✅ SDP project assets installed successfully!"
+echo "  SDP project assets installed successfully!"
 echo ""
+
+# Report backup location
+if [ -n "$SDP_BACKUP_DIR" ] && [ -d "$SDP_BACKUP_DIR" ]; then
+    echo "  Backup: $(cd .. && pwd)/.sdp/backup/"
+fi
+
 print_configured_integrations
 
 if [ "$SDP_AUTO_FALLBACK_ALL" = "1" ]; then

--- a/scripts/install-project.sh
+++ b/scripts/install-project.sh
@@ -52,8 +52,13 @@ fi
 # ---------------------------------------------------------------------------
 
 init_backup_dir() {
-    # Called before cd into $SDP_DIR. At this point cwd is the project root.
-    project_root="$(pwd)"
+    # Lazily creates the backup directory on first use.
+    # Not called from main flow — invoked by backup_file() so that
+    # preview mode (which never backs up) never creates the dir.
+    if [ -n "$SDP_BACKUP_DIR" ]; then
+        return
+    fi
+    project_root="$(cd "$SDP_DIR/.." && pwd)"
     mkdir -p "$project_root/.sdp/backup"
     SDP_BACKUP_DIR=$(mktemp -d "$project_root/.sdp/backup/XXXXXX")
 }
@@ -63,6 +68,7 @@ backup_file() {
     if [ ! -e "$file" ]; then
         return
     fi
+    init_backup_dir
     mkdir -p "$SDP_BACKUP_DIR"
     # Normalize path: strip leading ../ to get a clean relative path
     clean_path=$(echo "$file" | sed 's|^\.\./||')
@@ -155,26 +161,36 @@ merge_settings_json() {
     # We use a simple approach: for each top-level key in src,
     # if dest has it and it's an object/array, merge; otherwise set from src.
 
+    # Check if jq is available BEFORE attempting any JSON validation.
+    # If jq is absent and dest exists, we cannot safely merge or validate.
+    has_jq=0
+    if command -v jq >/dev/null 2>&1; then
+        has_jq=1
+    fi
+
     # Extract existing dest content
     dest_content=$(cat "$dest")
 
-    # Guard: skip merge if dest is empty or not valid JSON
-    if [ -z "$dest_content" ] || ! printf '%s' "$dest_content" | jq -e . >/dev/null 2>&1; then
-        echo "  Note: $dest is empty or invalid JSON — replacing with SDP defaults."
-        if [ "$SDP_PREVIEW" = "1" ]; then
-            preview_note "REPLACE (invalid JSON)" "$dest"
+    # Guard: skip merge if dest is empty or not valid JSON.
+    # Only runs when jq IS available (needed to validate JSON).
+    if [ "$has_jq" = "1" ]; then
+        if [ -z "$dest_content" ] || ! printf '%s' "$dest_content" | jq -e . >/dev/null 2>&1; then
+            echo "  Note: $dest is empty or invalid JSON — replacing with SDP defaults."
+            if [ "$SDP_PREVIEW" = "1" ]; then
+                preview_note "REPLACE (invalid JSON)" "$dest"
+                return
+            fi
+            backup_file "$dest"
+            mkdir -p "$(dirname "$dest")"
+            cp "$src" "$dest"
             return
         fi
-        backup_file "$dest"
-        mkdir -p "$(dirname "$dest")"
-        cp "$src" "$dest"
-        return
     fi
 
     src_content=$(cat "$src")
 
     # Check if jq is available for proper merge
-    if command -v jq >/dev/null 2>&1; then
+    if [ "$has_jq" = "1" ]; then
         # Proper deep merge with jq:
         # - For arrays under "hooks.*", append new entries (avoiding duplicates)
         # - For objects, merge recursively
@@ -389,12 +405,6 @@ update_existing_checkout() {
 }
 
 # ---------------------------------------------------------------------------
-# Initialize backup directory (before any modifications)
-# ---------------------------------------------------------------------------
-
-init_backup_dir
-
-# ---------------------------------------------------------------------------
 # Clone or update SDP checkout
 # ---------------------------------------------------------------------------
 
@@ -516,7 +526,15 @@ setup_claude() {
     sync_tree_files .claude/hooks ../.claude/hooks
     sync_tree_files .claude/patterns ../.claude/patterns
     # Merge settings.json instead of overwriting
-    merge_settings_json .claude/settings.json ../.claude/settings.json
+    if [ "$SDP_PRESERVE_CONFIG" = "1" ] && [ -f ../.claude/settings.json ]; then
+        if [ "$SDP_PREVIEW" = "1" ]; then
+            preview_note "SKIP (preserving existing)" "../.claude/settings.json"
+        else
+            echo "  Preserving existing .claude/settings.json (use --overwrite-config to replace)"
+        fi
+    else
+        merge_settings_json .claude/settings.json ../.claude/settings.json
+    fi
     register_integration "Claude" ".claude/"
 }
 

--- a/scripts/install-project.sh
+++ b/scripts/install-project.sh
@@ -6,7 +6,7 @@
 #
 # Flags:
 #   --preview             Show what would change without modifying anything.
-#   --no-overwrite-config Preserve existing IDE config files (legacy, default behavior).
+#   --no-overwrite-config Preserve existing IDE config files (default behavior).
 #   --overwrite-config    Overwrite existing config files (not recommended).
 
 set -eu
@@ -17,7 +17,7 @@ SDP_REF="${SDP_REF:-main}"
 REMOTE="${SDP_REMOTE:-https://github.com/fall-out-bug/sdp.git}"
 SDP_INSTALL_CLI="${SDP_INSTALL_CLI:-0}"
 SDP_INSTALL_CLI_FROM_SOURCE="${SDP_INSTALL_CLI_FROM_SOURCE:-0}"
-SDP_PRESERVE_CONFIG="${SDP_PRESERVE_CONFIG:-0}"
+SDP_PRESERVE_CONFIG="${SDP_PRESERVE_CONFIG:-1}"
 DEFAULT_REMOTE="https://github.com/fall-out-bug/sdp.git"
 SDP_AUTO_FALLBACK_ALL=0
 SDP_CONFIGURED_INTEGRATIONS=""
@@ -54,8 +54,8 @@ fi
 init_backup_dir() {
     # Called before cd into $SDP_DIR. At this point cwd is the project root.
     project_root="$(pwd)"
-    _rand=${RANDOM:-$(od -An -N2 -tu2 /dev/urandom 2>/dev/null | tr -d ' ')}
-    SDP_BACKUP_DIR="$project_root/.sdp/backup/$(date +%Y%m%dT%H%M%S)-$$_${_rand:-0}"
+    mkdir -p "$project_root/.sdp/backup"
+    SDP_BACKUP_DIR=$(mktemp -d "$project_root/.sdp/backup/XXXXXX")
 }
 
 backup_file() {
@@ -180,36 +180,38 @@ merge_settings_json() {
         # - For objects, merge recursively
         # - For scalars, take the source value only if missing from dest
 
-        merged=$(printf '%s\n%s\n' "$dest_content" "$src_content" | jq -n '
-            # inputs: [dest, src]
-            # Deep merge: dest as base, overlay src.
+        merged=$(jq -n \
+            --argjson user "$dest_content" \
+            --argjson sdp "$src_content" \
+        '
+            # Deep merge where USER values win on scalar conflicts.
+            # SDP only ADDS keys that the user does not have yet.
             # Arrays: concatenate and deduplicate (by value equality).
-            # Objects: recurse. Scalars: src wins (only when key is new or src differs).
-            [inputs] as $docs |
-            $docs[0] as $dest |
-            $docs[1] as $src |
+            # Objects: recurse. Scalars: user wins.
+            $user as $user |
+            $sdp as $sdp |
 
-            def deepmerge(a; b):
-              if (a | type) == "object" and (b | type) == "object" then
-                (a + b) | to_entries | map(
+            def deepmerge(u; s):
+              if (u | type) == "object" and (s | type) == "object" then
+                (s + u) | to_entries | map(
                   .key as $k |
-                  if ($k | in(a)) == false then .
-                  elif ($k | in(b)) == false then .key as $kk | {key: $kk, value: a[$kk]}
-                  elif (a[$k] | type) == "object" and (b[$k] | type) == "object" then
-                    {key: $k, value: (deepmerge(a[$k]; b[$k]))}
-                  elif (a[$k] | type) == "array" and (b[$k] | type) == "array" then
-                    {key: $k, value: (a[$k] + b[$k] | unique)}
+                  if ($k | in(s)) == false then .
+                  elif ($k | in(u)) == false then .key as $kk | {key: $kk, value: s[$kk]}
+                  elif (u[$k] | type) == "object" and (s[$k] | type) == "object" then
+                    {key: $k, value: (deepmerge(u[$k]; s[$k]))}
+                  elif (u[$k] | type) == "array" and (s[$k] | type) == "array" then
+                    {key: $k, value: (u[$k] + s[$k] | unique)}
                   else
-                    {key: $k, value: b[$k]}
+                    {key: $k, value: u[$k]}
                   end
                 ) | from_entries
-              elif (a | type) == "array" and (b | type) == "array" then
-                a + b | unique
+              elif (u | type) == "array" and (s | type) == "array" then
+                u + s | unique
               else
-                b
+                u
               end;
 
-            deepmerge($dest; $src)
+            deepmerge($user; $sdp)
         ')
 
         if [ "$SDP_PREVIEW" = "1" ]; then
@@ -232,14 +234,14 @@ $(echo "$merged" | head -20)"
                 echo "  Existing file preserved. SDP settings available at: $src"
             fi
         else
-            # Dest has no hooks — safe to append SDP content
-            # Simple append approach: take everything from src that's missing
+            # Dest exists but has no "hooks" key.  Without jq we cannot safely
+            # merge — refuse to overwrite and tell the user what to do.
             if [ "$SDP_PREVIEW" = "1" ]; then
-                preview_note "MERGE (basic, no jq)" "$dest"
+                preview_note "SKIP (jq required to merge safely)" "$dest"
             else
-                # Use the source file (dest had no hooks), but keep user keys
-                # Very basic: just overwrite. User was told to install jq.
-                cp "$src" "$dest"
+                echo "  WARNING: $dest exists but jq is not installed." >&2
+                echo "  jq is required to merge settings.json safely." >&2
+                echo "  Install jq or merge manually. SDP defaults available at: $src" >&2
             fi
         fi
     fi
@@ -413,6 +415,23 @@ else
     fi
 fi
 
+# In preview mode, if SDP checkout doesn't exist we cannot inspect its
+# contents.  Print the plan gathered so far and exit early.
+if [ "$SDP_PREVIEW" = "1" ] && [ ! -d "$SDP_DIR" ]; then
+    echo ""
+    echo "=== PREVIEW: Changes that would be made ==="
+    if [ -n "$SDP_PREVIEW_CHANGES" ]; then
+        echo "$SDP_PREVIEW_CHANGES" | grep -v '^$' | sed 's/^/  /'
+    else
+        echo "  (no changes)"
+    fi
+    echo ""
+    echo "Note: $SDP_DIR/ does not exist locally. A full preview requires the"
+    echo "checkout to be present. Run without --preview to clone and install."
+    echo "Existing configs will be backed up to .sdp/backup/ before modification."
+    exit 0
+fi
+
 cd "$SDP_DIR"
 
 # ---------------------------------------------------------------------------
@@ -559,13 +578,13 @@ done
 # ---------------------------------------------------------------------------
 
 if [ -f ../.gitignore ]; then
-    if ! grep -q "$SDP_DIR/.git" ../.gitignore; then
+    if ! grep -q "# >>> SDP_START >>>" ../.gitignore; then
         if [ "$SDP_PREVIEW" = "1" ]; then
             SDP_PREVIEW_CHANGES="$SDP_PREVIEW_CHANGES
-  APPEND: .gitignore (SDP entries)"
+  APPEND: .gitignore (SDP entries with explicit markers)"
         else
             echo "" >> ../.gitignore
-            echo "# SDP" >> ../.gitignore
+            echo "# >>> SDP_START >>>" >> ../.gitignore
             echo "$SDP_DIR/.git" >> ../.gitignore
             echo ".claude/skills" >> ../.gitignore
             echo ".claude/agents" >> ../.gitignore
@@ -576,7 +595,8 @@ if [ -f ../.gitignore ]; then
             echo ".codex/skills/sdp" >> ../.gitignore
             echo ".codex/agents" >> ../.gitignore
             echo ".prompts" >> ../.gitignore
-            echo "  Added entries to .gitignore"
+            echo "# <<< SDP_END <<<" >> ../.gitignore
+            echo "  Added entries to .gitignore (with explicit markers)"
         fi
     fi
 fi

--- a/scripts/install-project.sh
+++ b/scripts/install-project.sh
@@ -64,6 +64,8 @@ init_backup_dir() {
     SDP_BACKUP_DIR=$(mktemp -d "$project_root/.sdp/backup/XXXXXX")
 }
 
+# Note: backup files are not manifest-tracked; they live under .sdp/ which
+# is removed wholesale on uninstall (--purge) or left as-is in standard mode.
 backup_file() {
     file="$1"
     if [ ! -e "$file" ]; then
@@ -155,6 +157,8 @@ manifest_record() {
     echo "$entry" >> "$SDP_HOME/.sdp/manifest.jsonl"
 }
 
+# Note: directories are not manifest-tracked; uninstall handles empty-dir
+# cleanup separately (rmdir) and never force-removes populated dirs.
 safe_mkdir() {
     [ "$SDP_PREVIEW" = "1" ] && return 0
     mkdir -p "$1"

--- a/scripts/install-project.sh
+++ b/scripts/install-project.sh
@@ -648,6 +648,7 @@ if [ -f ../.gitignore ]; then
             echo ".prompts" >> ../.gitignore
             echo "# <<< SDP_END <<<" >> ../.gitignore
             echo "  Added entries to .gitignore (with explicit markers)"
+            manifest_record "append" "../.gitignore"
         fi
     fi
 fi
@@ -656,6 +657,9 @@ fi
 # Git hooks
 # ---------------------------------------------------------------------------
 
+# Hooks are installed by a dedicated script that manages its own manifest
+# entries for individual hook files. We record the hook directory here so
+# the uninstaller knows hooks were set up by SDP.
 if [ -f hooks/install-git-hooks.sh ]; then
     if [ "$SDP_PREVIEW" = "1" ]; then
         SDP_PREVIEW_CHANGES="$SDP_PREVIEW_CHANGES
@@ -663,6 +667,7 @@ if [ -f hooks/install-git-hooks.sh ]; then
     else
         if (cd .. && sh "$SDP_DIR/hooks/install-git-hooks.sh" 2>/dev/null); then
             echo "  Git hooks installed (pre-commit, pre-push)"
+            manifest_record "hooks" ".git/hooks"
         fi
     fi
 fi

--- a/scripts/install-project.sh
+++ b/scripts/install-project.sh
@@ -24,6 +24,7 @@ SDP_CONFIGURED_INTEGRATIONS=""
 SDP_PREVIEW=0
 SDP_BACKUP_DIR=""
 SDP_PREVIEW_CHANGES=""
+SDP_HOME=""  # resolved to project root after cd into SDP_DIR
 
 for arg in "$@"; do
     case "$arg" in
@@ -100,6 +101,7 @@ preview_link() {
     fi
     mkdir -p "$(dirname "$dest")"
     ln -sfn "$target" "$dest"
+    manifest_record "symlink" "$dest" "$target"
 }
 
 preview_tree() {
@@ -129,6 +131,33 @@ preview_file() {
 
     mkdir -p "$(dirname "$dest")"
     cp "$src" "$dest"
+    manifest_record "copy" "$dest"
+}
+
+# ---------------------------------------------------------------------------
+# Manifest helpers — record every file/symlink we create so uninstall is safe
+# ---------------------------------------------------------------------------
+
+# Resolve the project root (parent of SDP_DIR).  Called once after cd into
+# $SDP_DIR so that relative paths like ../.claude/... are stable.
+sdp_resolve_home() {
+    SDP_HOME="$(cd "$SDP_DIR/.." && pwd)"
+}
+
+manifest_record() {
+    local action="$1" path="$2" extra="${3:-}"
+    [ "$SDP_PREVIEW" = "1" ] && return 0
+    [ -z "$SDP_HOME" ] && sdp_resolve_home
+    mkdir -p "$SDP_HOME/.sdp"
+    local entry="{\"action\":\"$action\",\"path\":\"$path\""
+    [ -n "$extra" ] && entry="$entry,\"target\":\"$extra\""
+    entry="$entry,\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
+    echo "$entry" >> "$SDP_HOME/.sdp/manifest.jsonl"
+}
+
+safe_mkdir() {
+    [ "$SDP_PREVIEW" = "1" ] && return 0
+    mkdir -p "$1"
 }
 
 # ---------------------------------------------------------------------------
@@ -149,6 +178,7 @@ merge_settings_json() {
         fi
         mkdir -p "$(dirname "$dest")"
         cp "$src" "$dest"
+        manifest_record "copy" "$dest"
         return
     fi
 
@@ -183,6 +213,7 @@ merge_settings_json() {
             backup_file "$dest"
             mkdir -p "$(dirname "$dest")"
             cp "$src" "$dest"
+            manifest_record "copy" "$dest"
             return
         fi
     fi
@@ -237,6 +268,7 @@ merge_settings_json() {
 $(echo "$merged" | head -20)"
         else
             echo "$merged" > "$dest"
+            manifest_record "merge" "$dest"
         fi
     else
         # No jq: fall back to preserving existing file entirely.
@@ -443,6 +475,7 @@ if [ "$SDP_PREVIEW" = "1" ] && [ ! -d "$SDP_DIR" ]; then
 fi
 
 cd "$SDP_DIR"
+sdp_resolve_home
 
 # ---------------------------------------------------------------------------
 # Optional CLI install for project mode
@@ -519,7 +552,7 @@ else
 fi
 
 setup_claude() {
-    mkdir -p ../.claude
+    safe_mkdir ../.claude
     sync_link "../$SDP_DIR/prompts/skills" "../.claude/skills"
     sync_link "../$SDP_DIR/prompts/agents" "../.claude/agents"
     sync_file .claude/commands.json ../.claude/commands.json
@@ -539,25 +572,25 @@ setup_claude() {
 }
 
 setup_cursor() {
-    mkdir -p ../.cursor
+    safe_mkdir ../.cursor
     sync_link "../$SDP_DIR/prompts/skills" "../.cursor/skills"
     sync_link "../$SDP_DIR/prompts/agents" "../.cursor/agents"
-    mkdir -p ../.cursor/commands
+    safe_mkdir ../.cursor/commands
     sync_tree_files .cursor/commands ../.cursor/commands
     register_integration "Cursor" ".cursor/"
 }
 
 setup_opencode() {
-    mkdir -p ../.opencode
+    safe_mkdir ../.opencode
     sync_link "../$SDP_DIR/prompts/skills" "../.opencode/skills"
     sync_link "../$SDP_DIR/prompts/agents" "../.opencode/agents"
-    mkdir -p ../.opencode/commands
+    safe_mkdir ../.opencode/commands
     sync_tree_files .opencode/commands ../.opencode/commands
     register_integration "OpenCode" ".opencode/"
 }
 
 setup_codex() {
-    mkdir -p ../.codex/skills
+    safe_mkdir ../.codex/skills
     sync_link "../../$SDP_DIR/prompts/skills" "../.codex/skills/sdp"
     sync_link "../$SDP_DIR/prompts/agents" "../.codex/agents"
     sync_file .codex/INSTALL.md ../.codex/INSTALL.md

--- a/scripts/install-project.sh
+++ b/scripts/install-project.sh
@@ -54,7 +54,7 @@ fi
 init_backup_dir() {
     # Called before cd into $SDP_DIR. At this point cwd is the project root.
     project_root="$(pwd)"
-    SDP_BACKUP_DIR="$project_root/.sdp/backup/$(date +%Y%m%dT%H%M%S)"
+    SDP_BACKUP_DIR="$project_root/.sdp/backup/$(date +%Y%m%dT%H%M%S)-$$_${RANDOM:-0}"
 }
 
 backup_file() {
@@ -111,13 +111,13 @@ preview_file() {
     src="$1"
     dest="$2"
 
-    # Backup before overwrite
-    if [ "$SDP_PREVIEW" = "0" ] && [ -e "$dest" ]; then
-        backup_file "$dest"
-    fi
-
     if preview_note "COPY" "$dest"; then
         return
+    fi
+
+    # Backup before overwrite (after preview check to avoid side effects)
+    if [ -e "$dest" ]; then
+        backup_file "$dest"
     fi
 
     mkdir -p "$(dirname "$dest")"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,324 @@
+#!/bin/sh
+# SDP Uninstall Script
+#
+# Removes SDP artifacts from the current project while preserving user data.
+#
+# Usage:
+#   sh sdp/scripts/uninstall.sh              # Remove SDP artifacts, preserve user config
+#   sh sdp/scripts/uninstall.sh --purge       # Remove everything SDP-related
+#   sh sdp/scripts/uninstall.sh --dry-run     # Show what would be removed
+#
+# Flags:
+#   --dry-run   Show plan without executing
+#   --purge     Remove everything: SDP checkout, backups, all IDE integration dirs
+#   -y          Skip confirmation prompt
+
+set -eu
+
+SDP_DIR="${SDP_DIR:-sdp}"
+DRY_RUN=0
+PURGE=0
+SKIP_CONFIRM=0
+UNINSTALL_PLAN=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run)
+            DRY_RUN=1
+            ;;
+        --purge)
+            PURGE=1
+            ;;
+        -y)
+            SKIP_CONFIRM=1
+            ;;
+    esac
+done
+
+echo "SDP Uninstaller"
+echo "================"
+
+# Verify we're in a project root (has .git)
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+    echo "ERROR: Not in a git repository." >&2
+    exit 1
+fi
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+cd "$PROJECT_ROOT"
+
+# ---------------------------------------------------------------------------
+# Plan helpers
+# ---------------------------------------------------------------------------
+
+plan_remove_dir() {
+    dir="$1"
+    if [ -d "$dir" ]; then
+        UNINSTALL_PLAN="$UNINSTALL_PLAN
+  REMOVE DIR:  $dir/"
+    fi
+}
+
+plan_remove_file() {
+    file="$1"
+    if [ -f "$file" ]; then
+        UNINSTALL_PLAN="$UNINSTALL_PLAN
+  REMOVE FILE: $file"
+    fi
+}
+
+plan_remove_symlink() {
+    link="$1"
+    if [ -L "$link" ]; then
+        UNINSTALL_PLAN="$UNINSTALL_PLAN
+  REMOVE LINK: $link -> $(readlink "$link")"
+    fi
+}
+
+plan_remove_gitignore_block() {
+    if [ -f .gitignore ] && grep -q "# SDP" .gitignore; then
+        UNINSTALL_PLAN="$UNINSTALL_PLAN
+  REMOVE:      SDP entries from .gitignore"
+    fi
+}
+
+plan_remove_git_hooks() {
+    for hook in pre-commit pre-push; do
+        hook_path=".git/hooks/$hook"
+        if [ -L "$hook_path" ]; then
+            target=$(readlink "$hook_path")
+            case "$target" in
+                *sdp/hooks/*|*scripts/hooks/*)
+                    UNINSTALL_PLAN="$UNINSTALL_PLAN
+  REMOVE HOOK: $hook_path -> $target"
+                    ;;
+            esac
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Build plan
+# ---------------------------------------------------------------------------
+
+# SDP managed symlinks in .claude
+plan_remove_symlink .claude/skills
+plan_remove_symlink .claude/agents
+
+# SDP managed symlinks in .cursor
+plan_remove_symlink .cursor/skills
+plan_remove_symlink .cursor/agents
+
+# SDP managed symlinks in .opencode
+plan_remove_symlink .opencode/skills
+plan_remove_symlink .opencode/agents
+
+# SDP managed symlinks in .codex
+plan_remove_symlink .codex/skills/sdp
+plan_remove_symlink .codex/agents
+
+# SDP managed files (only those we installed)
+plan_remove_file .claude/commands.json
+plan_remove_file .codex/INSTALL.md
+plan_remove_file .codex/skills/README.md
+
+# Hooks installed by SDP
+plan_remove_git_hooks
+
+# .gitignore block
+plan_remove_gitignore_block
+
+# .sdp/backup directory (only in purge mode)
+if [ "$PURGE" = "1" ]; then
+    plan_remove_dir .sdp/backup
+    plan_remove_dir .sdp
+fi
+
+# SDP checkout directory
+if [ "$PURGE" = "1" ]; then
+    plan_remove_dir "$SDP_DIR"
+fi
+
+# Full IDE integration directories (only in purge mode)
+if [ "$PURGE" = "1" ]; then
+    plan_remove_dir .claude/hooks
+    plan_remove_dir .claude/patterns
+    # Note: we do NOT remove .claude/settings.json even in purge mode
+    # because it likely contains user customizations beyond SDP
+    UNINSTALL_PLAN="$UNINSTALL_PLAN
+  PRESERVE:    .claude/settings.json (may contain user config)"
+fi
+
+# ---------------------------------------------------------------------------
+# Display plan
+# ---------------------------------------------------------------------------
+
+if [ -z "$UNINSTALL_PLAN" ]; then
+    echo "No SDP artifacts found. Nothing to remove."
+    exit 0
+fi
+
+echo ""
+if [ "$PURGE" = "1" ]; then
+    echo "Mode: PURGE (remove all SDP artifacts)"
+elif [ "$DRY_RUN" = "1" ]; then
+    echo "Mode: DRY RUN (no changes will be made)"
+else
+    echo "Mode: STANDARD (remove SDP artifacts, preserve user data)"
+fi
+
+echo ""
+echo "Plan:"
+echo "$UNINSTALL_PLAN" | grep -v '^$'
+
+if [ "$DRY_RUN" = "1" ]; then
+    echo ""
+    echo "Run without --dry-run to execute this plan."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Confirm
+# ---------------------------------------------------------------------------
+
+if [ "$SKIP_CONFIRM" != "1" ]; then
+    echo ""
+    printf "Proceed? [y/N] "
+    read -r answer
+    case "$answer" in
+        [yY]|[yY][eE][sS])
+            ;;
+        *)
+            echo "Aborted."
+            exit 0
+            ;;
+    esac
+fi
+
+# ---------------------------------------------------------------------------
+# Execute
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Removing SDP artifacts..."
+
+# Remove symlinks (safe: symlinks are always SDP-managed)
+for link in \
+    .claude/skills .claude/agents \
+    .cursor/skills .cursor/agents \
+    .opencode/skills .opencode/agents \
+    .codex/skills/sdp .codex/agents; do
+    if [ -L "$link" ]; then
+        rm -f "$link"
+        echo "  Removed: $link"
+    fi
+done
+
+# Remove SDP-installed files
+for file in .claude/commands.json .codex/INSTALL.md .codex/skills/README.md; do
+    if [ -f "$file" ]; then
+        rm -f "$file"
+        echo "  Removed: $file"
+    fi
+done
+
+# Remove git hooks that point to SDP
+for hook in pre-commit pre-push; do
+    hook_path=".git/hooks/$hook"
+    if [ -L "$hook_path" ]; then
+        target=$(readlink "$hook_path")
+        case "$target" in
+            *sdp/hooks/*|*scripts/hooks/*)
+                rm -f "$hook_path"
+                echo "  Removed hook: $hook_path"
+                ;;
+        esac
+    fi
+done
+
+# Remove .gitignore SDP block
+if [ -f .gitignore ] && grep -q "# SDP" .gitignore; then
+    # Remove the SDP block: from "# SDP" line to the next blank line or EOF
+    # Use a portable approach
+    if command -v sed >/dev/null 2>&1; then
+        # Remove lines between "# SDP" marker and next empty line (inclusive)
+        sed -i.bak '/^# SDP$/,/^[[:space:]]*$/{ /^$/!d; }' .gitignore 2>/dev/null || \
+        sed -i '' '/^# SDP$/,/^[[:space:]]*$/{ /^$/!d; }' .gitignore 2>/dev/null || true
+        # Also remove specific SDP-managed entries (in case the block approach missed some)
+        for entry in \
+            "$SDP_DIR/.git" \
+            ".claude/skills" \
+            ".claude/agents" \
+            ".cursor/skills" \
+            ".cursor/agents" \
+            ".opencode/skills" \
+            ".opencode/agents" \
+            ".codex/skills/sdp" \
+            ".codex/agents" \
+            ".prompts"; do
+            # Remove the line (GNU or BSD sed)
+            sed -i.bak "\|^${entry}$|d" .gitignore 2>/dev/null || \
+            sed -i '' "\|^${entry}$|d" .gitignore 2>/dev/null || true
+        done
+        rm -f .gitignore.bak
+        # Clean up trailing blank lines
+        sed -i.bak -e :a -e '/^\n*$/{$d;N;ba' -e '}' .gitignore 2>/dev/null || \
+        sed -i '' -e :a -e '/^\n*$/{$d;N;ba' -e '}' .gitignore 2>/dev/null || true
+        rm -f .gitignore.bak
+        echo "  Cleaned: .gitignore SDP entries"
+    fi
+fi
+
+# Purge mode: remove additional directories
+if [ "$PURGE" = "1" ]; then
+    # Remove .claude/hooks (SDP-installed hook scripts)
+    if [ -d .claude/hooks ]; then
+        rm -rf .claude/hooks
+        echo "  Removed: .claude/hooks/"
+    fi
+
+    # Remove .claude/patterns (SDP-installed patterns)
+    if [ -d .claude/patterns ]; then
+        rm -rf .claude/patterns
+        echo "  Removed: .claude/patterns/"
+    fi
+
+    # Remove .sdp directory (config, backups, everything)
+    if [ -d .sdp ]; then
+        rm -rf .sdp
+        echo "  Removed: .sdp/"
+    fi
+
+    # Remove SDP checkout directory
+    if [ -d "$SDP_DIR" ]; then
+        rm -rf "$SDP_DIR"
+        echo "  Removed: $SDP_DIR/"
+    fi
+fi
+
+# Clean up empty directories left behind
+for dir in .codex/skills .codex .claude .cursor .opencode; do
+    if [ -d "$dir" ] && [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+        rmdir "$dir" 2>/dev/null && echo "  Cleaned empty dir: $dir/" || true
+    fi
+done
+
+echo ""
+if [ "$PURGE" = "1" ]; then
+    echo "  SDP fully purged from this project."
+    echo ""
+    echo "  Preserved (may contain your data):"
+    echo "    .claude/settings.json"
+    echo "    .cursor/ (non-SDP files)"
+    echo "    .opencode/ (non-SDP files)"
+else
+    echo "  SDP artifacts removed. User data preserved."
+    echo ""
+    echo "  Preserved:"
+    echo "    .claude/settings.json (your IDE settings)"
+    echo "    .sdp/ (project config and backups)"
+    echo "    $SDP_DIR/ (SDP checkout)"
+    echo ""
+    echo "  To remove everything, run: sh $SDP_DIR/scripts/uninstall.sh --purge"
+    echo "  To reinstall: sh $SDP_DIR/scripts/install-project.sh"
+fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -12,6 +12,12 @@
 #   --dry-run   Show plan without executing
 #   --purge     Remove everything: SDP checkout, backups, all IDE integration dirs
 #   -y          Skip confirmation prompt
+#
+# Cleanup strategy:
+# 1. Manifest-based: remove files listed in .sdp/manifest.jsonl (primary)
+# 2. Marker/symlink-based: remove SDP blocks from .gitignore, SDP hooks by symlink target
+# 3. Legacy fallback: pattern-based removal when no manifest exists (migration path)
+# Directories (.claude/, .cursor/) are not removed unless empty or SDP-owned symlinks
 
 set -eu
 
@@ -150,8 +156,11 @@ if [ "$HAS_MANIFEST" = "1" ]; then
         esac
     done < "$MANIFEST_FILE"
 else
-    echo "WARNING: No install manifest found (.sdp/manifest.jsonl)." >&2
-    echo "  Falling back to pattern-based removal (may remove user-created files)." >&2
+    echo "============================================================" >&2
+    echo "WARNING: Legacy install detected (no .sdp/manifest.jsonl)." >&2
+    echo "Removing SDP artifacts by hardcoded pattern." >&2
+    echo "If this is incorrect, restore from .sdp/backup/." >&2
+    echo "============================================================" >&2
     # Legacy fallback: plan by pattern
     plan_remove_symlink .claude/skills
     plan_remove_symlink .claude/agents
@@ -190,9 +199,18 @@ if [ "$PURGE" = "1" ]; then
 fi
 
 # Full IDE integration directories (only in purge mode)
+# Only plan removal if SDP-owned symlink or empty directory — never blind rm -rf
 if [ "$PURGE" = "1" ]; then
-    plan_remove_dir .claude/hooks
-    plan_remove_dir .claude/patterns
+    if [ -L ".claude/hooks" ] && is_sdp_symlink ".claude/hooks"; then
+        plan_remove_symlink .claude/hooks
+    elif [ -d ".claude/hooks" ] && [ -z "$(ls -A .claude/hooks 2>/dev/null)" ]; then
+        plan_remove_dir .claude/hooks
+    fi
+    if [ -L ".claude/patterns" ] && is_sdp_symlink ".claude/patterns"; then
+        plan_remove_symlink .claude/patterns
+    elif [ -d ".claude/patterns" ] && [ -z "$(ls -A .claude/patterns 2>/dev/null)" ]; then
+        plan_remove_dir .claude/patterns
+    fi
     # Note: we do NOT remove .claude/settings.json even in purge mode
     # because it likely contains user customizations beyond SDP
     UNINSTALL_PLAN="$UNINSTALL_PLAN
@@ -344,26 +362,26 @@ fi
 
 # Purge mode: remove additional directories.
 # .claude/hooks and .claude/patterns are only removed in purge mode because
-# they may contain user-authored scripts.  The .claude/hooks symlink case is
-# checked first: if it points into SDP we remove it; if it's a real directory
-# we still remove it in purge (user explicitly asked for full cleanup).
+# they may contain user-authored scripts.  Removal is guarded:
+# - SDP-owned symlink: always safe to remove
+# - Real directory: only removed if empty (rmdir, not rm -rf)
 if [ "$PURGE" = "1" ]; then
-    # Remove .claude/hooks (SDP-installed hook scripts)
-    if [ -L .claude/hooks ] && is_sdp_symlink .claude/hooks; then
-        rm -f .claude/hooks
+    # Remove .claude/hooks — only if it is an SDP-owned symlink or empty dir
+    if [ -L ".claude/hooks" ] && is_sdp_symlink ".claude/hooks"; then
+        rm -f ".claude/hooks"
         echo "  Removed symlink: .claude/hooks/"
-    elif [ -d .claude/hooks ]; then
-        rm -rf .claude/hooks
-        echo "  Removed: .claude/hooks/"
+    elif [ -d ".claude/hooks" ] && [ -z "$(ls -A .claude/hooks 2>/dev/null)" ]; then
+        rmdir ".claude/hooks"
+        echo "  Removed empty dir: .claude/hooks/"
     fi
 
-    # Remove .claude/patterns (SDP-installed patterns)
-    if [ -L .claude/patterns ] && is_sdp_symlink .claude/patterns; then
-        rm -f .claude/patterns
+    # Remove .claude/patterns — only if it is an SDP-owned symlink or empty dir
+    if [ -L ".claude/patterns" ] && is_sdp_symlink ".claude/patterns"; then
+        rm -f ".claude/patterns"
         echo "  Removed symlink: .claude/patterns/"
-    elif [ -d .claude/patterns ]; then
-        rm -rf .claude/patterns
-        echo "  Removed: .claude/patterns/"
+    elif [ -d ".claude/patterns" ] && [ -z "$(ls -A .claude/patterns 2>/dev/null)" ]; then
+        rmdir ".claude/patterns"
+        echo "  Removed empty dir: .claude/patterns/"
     fi
 
     # Remove .sdp directory (config, backups, manifest, everything)

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -52,6 +52,19 @@ cd "$PROJECT_ROOT"
 # Manifest helpers
 # ---------------------------------------------------------------------------
 
+# is_sdp_symlink PATH — returns 0 if PATH is a symlink whose target contains
+# "sdp" in its resolved path.  Used to guard hook removal so we never delete
+# hooks that belong to another tool.
+is_sdp_symlink() {
+    _path="$1"
+    [ -L "$_path" ] || return 1
+    _target=$(readlink "$_path")
+    case "$_target" in
+        *sdp*) return 0 ;;
+        *)     return 1 ;;
+    esac
+}
+
 MANIFEST_FILE=".sdp/manifest.jsonl"
 HAS_MANIFEST=0
 
@@ -153,10 +166,16 @@ else
     plan_remove_file .codex/skills/README.md
 fi
 
-# Hooks installed by SDP (always checked — not in manifest yet)
+# Git hooks: NOT tracked by the manifest because they live inside .git/hooks/
+# and are managed by a dedicated installer script.  Cleanup is safe because we
+# only remove hooks that are symlinks pointing into an SDP path (checked via
+# is_sdp_symlink / readlink).
 plan_remove_git_hooks
 
-# .gitignore block (always checked)
+# .gitignore: NOT tracked line-by-line in the manifest because it is a shared
+# config file.  Cleanup uses marker-based removal (# >>> SDP_START >>> ...
+# # <<< SDP_END <<<) so only the SDP block is stripped, preserving all other
+# entries.  This is safe by design — markers are unique to SDP installs.
 plan_remove_gitignore_block
 
 # .sdp/backup directory (only in purge mode)
@@ -276,17 +295,14 @@ else
     done
 fi
 
-# Remove git hooks that point to SDP (always — hooks are outside manifest scope)
+# Remove git hooks that point into an SDP checkout.
+# Only removes symlinks whose target contains "sdp" — never deletes hooks
+# that belong to another tool (e.g. husky, lefthook).
 for hook in pre-commit pre-push; do
     hook_path=".git/hooks/$hook"
-    if [ -L "$hook_path" ]; then
-        target=$(readlink "$hook_path")
-        case "$target" in
-            *sdp/hooks/*|*scripts/hooks/*)
-                rm -f "$hook_path"
-                echo "  Removed hook: $hook_path"
-                ;;
-        esac
+    if is_sdp_symlink "$hook_path"; then
+        rm -f "$hook_path"
+        echo "  Removed hook: $hook_path"
     fi
 done
 
@@ -326,16 +342,26 @@ if [ -f .gitignore ] && grep -q "^# SDP" .gitignore; then
     fi
 fi
 
-# Purge mode: remove additional directories
+# Purge mode: remove additional directories.
+# .claude/hooks and .claude/patterns are only removed in purge mode because
+# they may contain user-authored scripts.  The .claude/hooks symlink case is
+# checked first: if it points into SDP we remove it; if it's a real directory
+# we still remove it in purge (user explicitly asked for full cleanup).
 if [ "$PURGE" = "1" ]; then
     # Remove .claude/hooks (SDP-installed hook scripts)
-    if [ -d .claude/hooks ]; then
+    if [ -L .claude/hooks ] && is_sdp_symlink .claude/hooks; then
+        rm -f .claude/hooks
+        echo "  Removed symlink: .claude/hooks/"
+    elif [ -d .claude/hooks ]; then
         rm -rf .claude/hooks
         echo "  Removed: .claude/hooks/"
     fi
 
     # Remove .claude/patterns (SDP-installed patterns)
-    if [ -d .claude/patterns ]; then
+    if [ -L .claude/patterns ] && is_sdp_symlink .claude/patterns; then
+        rm -f .claude/patterns
+        echo "  Removed symlink: .claude/patterns/"
+    elif [ -d .claude/patterns ]; then
         rm -rf .claude/patterns
         echo "  Removed: .claude/patterns/"
     fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -16,6 +16,7 @@
 set -eu
 
 SDP_DIR="${SDP_DIR:-sdp}"
+: "${SDP_DIR:?ERROR: SDP_DIR must not be empty}"
 DRY_RUN=0
 PURGE=0
 SKIP_CONFIRM=0
@@ -174,7 +175,7 @@ echo "$UNINSTALL_PLAN" | grep -v '^$'
 if [ "$DRY_RUN" = "1" ]; then
     echo ""
     echo "Run without --dry-run to execute this plan."
-    exit 0
+    exit 2
 fi
 
 # ---------------------------------------------------------------------------
@@ -290,7 +291,7 @@ if [ "$PURGE" = "1" ]; then
     fi
 
     # Remove SDP checkout directory
-    if [ -d "$SDP_DIR" ]; then
+    if [ -n "${SDP_DIR:-}" ] && [ -d "$SDP_DIR" ]; then
         rm -rf "$SDP_DIR"
         echo "  Removed: $SDP_DIR/"
     fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -77,9 +77,16 @@ plan_remove_symlink() {
 }
 
 plan_remove_gitignore_block() {
-    if [ -f .gitignore ] && grep -q "# >>> SDP_START >>>" .gitignore; then
-        UNINSTALL_PLAN="$UNINSTALL_PLAN
+    if [ -f .gitignore ]; then
+        if grep -q "# >>> SDP_START >>>" .gitignore; then
+            UNINSTALL_PLAN="$UNINSTALL_PLAN
   REMOVE:      SDP entries from .gitignore (between explicit markers)"
+        fi
+        # Also detect legacy "# SDP" markers from older installs
+        if grep -q "^# SDP" .gitignore; then
+            UNINSTALL_PLAN="$UNINSTALL_PLAN
+  REMOVE:      Legacy SDP entries from .gitignore (# SDP marker)"
+        fi
     fi
 }
 
@@ -249,6 +256,31 @@ if [ -f .gitignore ] && grep -q "# >>> SDP_START >>>" .gitignore; then
         sed -i '' '/^$/{ N; /^\n$/d; }' .gitignore 2>/dev/null || true
         rm -f .gitignore.bak
         echo "  Cleaned: .gitignore SDP entries (between markers)"
+    fi
+fi
+
+# Remove legacy "# SDP" marker blocks from older installs.
+# Old format: lines starting with "# SDP" up to next blank line or "# >>>" marker.
+if [ -f .gitignore ] && grep -q "^# SDP" .gitignore; then
+    if command -v sed >/dev/null 2>&1; then
+        # Remove lines that start with "# SDP" (the old marker comment)
+        sed -i.bak '/^# SDP/d' .gitignore 2>/dev/null || \
+        sed -i '' '/^# SDP/d' .gitignore 2>/dev/null || true
+        rm -f .gitignore.bak
+        # Remove any orphaned SDP-related entries that followed the old marker
+        for entry in "$SDP_DIR/.git" ".claude/skills" ".claude/agents" \
+                     ".cursor/skills" ".cursor/agents" \
+                     ".opencode/skills" ".opencode/agents" \
+                     ".codex/skills/sdp" ".codex/agents" ".prompts"; do
+            sed -i.bak "\|^${entry}\$|d" .gitignore 2>/dev/null || \
+            sed -i '' "\|^${entry}\$|d" .gitignore 2>/dev/null || true
+            rm -f .gitignore.bak
+        done
+        # Clean up consecutive blank lines left behind
+        sed -i.bak '/^$/{ N; /^\n$/d; }' .gitignore 2>/dev/null || \
+        sed -i '' '/^$/{ N; /^\n$/d; }' .gitignore 2>/dev/null || true
+        rm -f .gitignore.bak
+        echo "  Cleaned: .gitignore legacy SDP entries (# SDP marker)"
     fi
 fi
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -49,6 +49,17 @@ PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 cd "$PROJECT_ROOT"
 
 # ---------------------------------------------------------------------------
+# Manifest helpers
+# ---------------------------------------------------------------------------
+
+MANIFEST_FILE=".sdp/manifest.jsonl"
+HAS_MANIFEST=0
+
+if [ -f "$MANIFEST_FILE" ]; then
+    HAS_MANIFEST=1
+fi
+
+# ---------------------------------------------------------------------------
 # Plan helpers
 # ---------------------------------------------------------------------------
 
@@ -106,34 +117,46 @@ plan_remove_git_hooks() {
 }
 
 # ---------------------------------------------------------------------------
-# Build plan
+# Build plan — manifest-aware
 # ---------------------------------------------------------------------------
 
-# SDP managed symlinks in .claude
-plan_remove_symlink .claude/skills
-plan_remove_symlink .claude/agents
+if [ "$HAS_MANIFEST" = "1" ]; then
+    echo "Using install manifest: $MANIFEST_FILE"
+    # Plan from manifest
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        action=$(echo "$line" | sed 's/.*"action":"\([^"]*\)".*/\1/')
+        path=$(echo "$line" | sed 's/.*"path":"\([^"]*\)".*/\1/')
+        case "$action" in
+            symlink)
+                plan_remove_symlink "$path"
+                ;;
+            copy|merge)
+                plan_remove_file "$path"
+                ;;
+        esac
+    done < "$MANIFEST_FILE"
+else
+    echo "WARNING: No install manifest found (.sdp/manifest.jsonl)." >&2
+    echo "  Falling back to pattern-based removal (may remove user-created files)." >&2
+    # Legacy fallback: plan by pattern
+    plan_remove_symlink .claude/skills
+    plan_remove_symlink .claude/agents
+    plan_remove_symlink .cursor/skills
+    plan_remove_symlink .cursor/agents
+    plan_remove_symlink .opencode/skills
+    plan_remove_symlink .opencode/agents
+    plan_remove_symlink .codex/skills/sdp
+    plan_remove_symlink .codex/agents
+    plan_remove_file .claude/commands.json
+    plan_remove_file .codex/INSTALL.md
+    plan_remove_file .codex/skills/README.md
+fi
 
-# SDP managed symlinks in .cursor
-plan_remove_symlink .cursor/skills
-plan_remove_symlink .cursor/agents
-
-# SDP managed symlinks in .opencode
-plan_remove_symlink .opencode/skills
-plan_remove_symlink .opencode/agents
-
-# SDP managed symlinks in .codex
-plan_remove_symlink .codex/skills/sdp
-plan_remove_symlink .codex/agents
-
-# SDP managed files (only those we installed)
-plan_remove_file .claude/commands.json
-plan_remove_file .codex/INSTALL.md
-plan_remove_file .codex/skills/README.md
-
-# Hooks installed by SDP
+# Hooks installed by SDP (always checked — not in manifest yet)
 plan_remove_git_hooks
 
-# .gitignore block
+# .gitignore block (always checked)
 plan_remove_gitignore_block
 
 # .sdp/backup directory (only in purge mode)
@@ -210,27 +233,50 @@ fi
 echo ""
 echo "Removing SDP artifacts..."
 
-# Remove symlinks (safe: symlinks are always SDP-managed)
-for link in \
-    .claude/skills .claude/agents \
-    .cursor/skills .cursor/agents \
-    .opencode/skills .opencode/agents \
-    .codex/skills/sdp .codex/agents; do
-    if [ -L "$link" ]; then
-        rm -f "$link"
-        echo "  Removed: $link"
-    fi
-done
+if [ "$HAS_MANIFEST" = "1" ]; then
+    # Manifest-driven removal: only remove files SDP actually created
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        action=$(echo "$line" | sed 's/.*"action":"\([^"]*\)".*/\1/')
+        path=$(echo "$line" | sed 's/.*"path":"\([^"]*\)".*/\1/')
+        case "$action" in
+            symlink)
+                if [ -L "$path" ]; then
+                    rm -f "$path"
+                    echo "  Removed symlink: $path"
+                fi
+                ;;
+            copy|merge)
+                if [ -f "$path" ]; then
+                    rm -f "$path"
+                    echo "  Removed file: $path"
+                fi
+                ;;
+        esac
+    done < "$MANIFEST_FILE"
+else
+    # Legacy fallback: remove by known patterns
+    echo "  (legacy mode — pattern-based removal)" >&2
+    for link in \
+        .claude/skills .claude/agents \
+        .cursor/skills .cursor/agents \
+        .opencode/skills .opencode/agents \
+        .codex/skills/sdp .codex/agents; do
+        if [ -L "$link" ]; then
+            rm -f "$link"
+            echo "  Removed: $link"
+        fi
+    done
 
-# Remove SDP-installed files
-for file in .claude/commands.json .codex/INSTALL.md .codex/skills/README.md; do
-    if [ -f "$file" ]; then
-        rm -f "$file"
-        echo "  Removed: $file"
-    fi
-done
+    for file in .claude/commands.json .codex/INSTALL.md .codex/skills/README.md; do
+        if [ -f "$file" ]; then
+            rm -f "$file"
+            echo "  Removed: $file"
+        fi
+    done
+fi
 
-# Remove git hooks that point to SDP
+# Remove git hooks that point to SDP (always — hooks are outside manifest scope)
 for hook in pre-commit pre-push; do
     hook_path=".git/hooks/$hook"
     if [ -L "$hook_path" ]; then
@@ -260,14 +306,11 @@ if [ -f .gitignore ] && grep -q "# >>> SDP_START >>>" .gitignore; then
 fi
 
 # Remove legacy "# SDP" marker blocks from older installs.
-# Old format: lines starting with "# SDP" up to next blank line or "# >>>" marker.
 if [ -f .gitignore ] && grep -q "^# SDP" .gitignore; then
     if command -v sed >/dev/null 2>&1; then
-        # Remove lines that start with "# SDP" (the old marker comment)
         sed -i.bak '/^# SDP/d' .gitignore 2>/dev/null || \
         sed -i '' '/^# SDP/d' .gitignore 2>/dev/null || true
         rm -f .gitignore.bak
-        # Remove any orphaned SDP-related entries that followed the old marker
         for entry in "$SDP_DIR/.git" ".claude/skills" ".claude/agents" \
                      ".cursor/skills" ".cursor/agents" \
                      ".opencode/skills" ".opencode/agents" \
@@ -276,7 +319,6 @@ if [ -f .gitignore ] && grep -q "^# SDP" .gitignore; then
             sed -i '' "\|^${entry}\$|d" .gitignore 2>/dev/null || true
             rm -f .gitignore.bak
         done
-        # Clean up consecutive blank lines left behind
         sed -i.bak '/^$/{ N; /^\n$/d; }' .gitignore 2>/dev/null || \
         sed -i '' '/^$/{ N; /^\n$/d; }' .gitignore 2>/dev/null || true
         rm -f .gitignore.bak
@@ -298,7 +340,7 @@ if [ "$PURGE" = "1" ]; then
         echo "  Removed: .claude/patterns/"
     fi
 
-    # Remove .sdp directory (config, backups, everything)
+    # Remove .sdp directory (config, backups, manifest, everything)
     if [ -d .sdp ]; then
         rm -rf .sdp
         echo "  Removed: .sdp/"
@@ -317,6 +359,16 @@ for dir in .codex/skills .codex .claude .cursor .opencode; do
         rmdir "$dir" 2>/dev/null && echo "  Cleaned empty dir: $dir/" || true
     fi
 done
+
+# Remove manifest itself in standard mode (if it still exists)
+if [ "$HAS_MANIFEST" = "1" ] && [ "$PURGE" != "1" ] && [ -f "$MANIFEST_FILE" ]; then
+    rm -f "$MANIFEST_FILE"
+    echo "  Removed: $MANIFEST_FILE"
+    # Clean up .sdp dir if empty
+    if [ -d .sdp ] && [ -z "$(ls -A .sdp 2>/dev/null)" ]; then
+        rmdir .sdp 2>/dev/null && echo "  Cleaned empty dir: .sdp/" || true
+    fi
+fi
 
 echo ""
 if [ "$PURGE" = "1" ]; then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -77,9 +77,9 @@ plan_remove_symlink() {
 }
 
 plan_remove_gitignore_block() {
-    if [ -f .gitignore ] && grep -q "# SDP" .gitignore; then
+    if [ -f .gitignore ] && grep -q "# >>> SDP_START >>>" .gitignore; then
         UNINSTALL_PLAN="$UNINSTALL_PLAN
-  REMOVE:      SDP entries from .gitignore"
+  REMOVE:      SDP entries from .gitignore (between explicit markers)"
     fi
 }
 
@@ -237,36 +237,18 @@ for hook in pre-commit pre-push; do
     fi
 done
 
-# Remove .gitignore SDP block
-if [ -f .gitignore ] && grep -q "# SDP" .gitignore; then
-    # Remove the SDP block: from "# SDP" line to the next blank line or EOF
-    # Use a portable approach
+# Remove .gitignore SDP block (between explicit markers)
+if [ -f .gitignore ] && grep -q "# >>> SDP_START >>>" .gitignore; then
     if command -v sed >/dev/null 2>&1; then
-        # Remove lines between "# SDP" marker and next empty line (inclusive)
-        sed -i.bak '/^# SDP$/,/^[[:space:]]*$/{ /^$/!d; }' .gitignore 2>/dev/null || \
-        sed -i '' '/^# SDP$/,/^[[:space:]]*$/{ /^$/!d; }' .gitignore 2>/dev/null || true
-        # Also remove specific SDP-managed entries (in case the block approach missed some)
-        for entry in \
-            "$SDP_DIR/.git" \
-            ".claude/skills" \
-            ".claude/agents" \
-            ".cursor/skills" \
-            ".cursor/agents" \
-            ".opencode/skills" \
-            ".opencode/agents" \
-            ".codex/skills/sdp" \
-            ".codex/agents" \
-            ".prompts"; do
-            # Remove the line (GNU or BSD sed)
-            sed -i.bak "\|^${entry}$|d" .gitignore 2>/dev/null || \
-            sed -i '' "\|^${entry}$|d" .gitignore 2>/dev/null || true
-        done
+        # Remove lines between (and including) the SDP markers
+        sed -i.bak '/^# >>> SDP_START >>>$/,/^# <<< SDP_END <<<$/d' .gitignore 2>/dev/null || \
+        sed -i '' '/^# >>> SDP_START >>>$/,/^# <<< SDP_END <<<$/d' .gitignore 2>/dev/null || true
         rm -f .gitignore.bak
-        # Clean up trailing blank lines
-        sed -i.bak -e :a -e '/^\n*$/{$d;N;ba' -e '}' .gitignore 2>/dev/null || \
-        sed -i '' -e :a -e '/^\n*$/{$d;N;ba' -e '}' .gitignore 2>/dev/null || true
+        # Clean up consecutive blank lines left behind
+        sed -i.bak '/^$/{ N; /^\n$/d; }' .gitignore 2>/dev/null || \
+        sed -i '' '/^$/{ N; /^\n$/d; }' .gitignore 2>/dev/null || true
         rm -f .gitignore.bak
-        echo "  Cleaned: .gitignore SDP entries"
+        echo "  Cleaned: .gitignore SDP entries (between markers)"
     fi
 fi
 


### PR DESCRIPTION
## Summary
- **F099-01**: Safe install with backup, merge (jq deep merge, user-wins-on-conflict), preview mode, and full uninstall scripts
- **F099-03**: Comprehensive adoption guide document (ADOPTION.md) with spec-level disclaimers
- All internal review cycles passed (P0-P3 clean, 17/17 PASS)

## Key Design Decisions
1. **Preserve-by-default**: `SDP_PRESERVE_CONFIG=1` — existing configs never overwritten without explicit `--overwrite-config`
2. **User-wins merge**: jq merge prefers existing user values; SDP only adds new keys
3. **Marker-based .gitignore cleanup**: Uses `# >>> SDP_START >>>` / `# <<< SDP_END <<<` to avoid deleting unrelated entries
4. **No-jq safety**: Refuses to overwrite settings.json when jq unavailable; prints clear manual-merge instructions
5. **mktemp backups**: Guaranteed unique backup directories via `mktemp -d`

## Changes
- `sdp/scripts/install-project.sh` — backup, preserve-by-default merge, --preview, mktemp, marker-based gitignore
- `sdp/scripts/uninstall.sh` — new file: marker-based removal, --dry-run (exit 2), --purge, confirmation prompt, empty-var guards
- `sdp/docs/ADOPTION.md` — new file: adoption guide with install matrix, workflows, FAQ
- `sdp/install.sh` — header update
- `sdp/docs/QUICKSTART.md` — update to reference adoption guide
- `sdp/CLAUDE.md` — progressive disclosure restructure

## Review Trail
1. Build → Review #1: CHANGES_REQUIRED (P0-P1 issues)
2. Design → Build fixes → Review #2: APPROVED (P0-P1 fixed)
3. Build P2/P3 → Review #3: APPROVED 17/17 PASS
4. PR review (codex:rescue): REQUEST_CHANGES (3 blockers, 3 important)
5. Build fixes → **current state**

## Test plan
- [x] `bash -n` passes on all scripts
- [x] All code fences in ADOPTION.md validated
- [ ] Manual smoke test: install on fresh repo with --preview
- [ ] Manual smoke test: install on existing project (preserve mode)
- [ ] Manual smoke test: uninstall --dry-run
- [ ] Manual smoke test: uninstall --purge

🤖 Generated with [Claude Code](https://claude.com/claude-code)