### PR TITLE
feat(F101): Write Plan Emission and Confirmation

### DIFF
--- a/prompts/skills/bugfix/SKILL.md
+++ b/prompts/skills/bugfix/SKILL.md
@@ -26,15 +26,16 @@ Quality bug fixes with full TDD cycle. Branch from master via feature/.
 
 Before modifying any file, emit a write plan:
 
-1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason (test files, fix files, branch operations).
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason (test files and fix files).
 2. **Flags:**
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
 4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"bugfix"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"bugfix"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id if known>","workstream_id":"<ws-id if applicable>"}}
    ```
+   Include context fields only when the ID is known at plan time. Omit unavailable fields rather than inventing placeholders.
    > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**

--- a/prompts/skills/bugfix/SKILL.md
+++ b/prompts/skills/bugfix/SKILL.md
@@ -22,6 +22,35 @@ Quality bug fixes with full TDD cycle. Branch from master via feature/.
 5. **Commit** — `git commit -m "fix(scope): description"`
 6. **Push** — `git push -u origin fix/{branch}` then `gh pr create --base master`
 
+## Write Plan (F101)
+
+Before modifying any file, emit a write plan:
+
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason (test files, fix files, branch operations).
+2. **Flags:**
+   - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
+   - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
+3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+   ```json
+   {"ts":"<ISO-8601>","type":"write_plan","skill":"bugfix","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   ```
+
+**Output format:**
+```
+WRITE PLAN for @bugfix <target>:
+  CREATE: path/to/new/file — <reason>
+  MODIFY: path/to/existing/file — <reason>
+  DELETE: path/to/removed/file — <reason>
+
+Proceed? [y/n]
+```
+
+**Modes:**
+- No flag: Show plan → Confirm → Execute
+- `--dry-run`: Show plan → STOP
+- `--yes`: Show plan → Execute immediately (no prompt)
+
 ## Output
 
 Bug fixed, tests added, issue closed, changes pushed.

--- a/prompts/skills/bugfix/SKILL.md
+++ b/prompts/skills/bugfix/SKILL.md
@@ -31,10 +31,11 @@ Before modifying any file, emit a write plan:
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
-4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"ts":"<ISO-8601>","type":"write_plan","skill":"bugfix","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"bugfix"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
    ```
+   > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**
 ```

--- a/prompts/skills/build/SKILL.md
+++ b/prompts/skills/build/SKILL.md
@@ -35,37 +35,6 @@ Continuation is the orchestrator's job (@oneshot / sdp orchestrate).
 
 ---
 
-## Write Plan (F101)
-
-Before the TDD cycle (step 2 of EXECUTE THIS NOW), emit a write plan:
-
-1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason.
-2. **Flags:**
-   - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
-   - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
-3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
-4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
-   ```json
-   {"ts":"<ISO-8601>","type":"write_plan","skill":"build","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
-   ```
-
-**Output format:**
-```
-WRITE PLAN for @build <ws-id>:
-  CREATE: path/to/new/file — <reason>
-  MODIFY: path/to/existing/file — <reason>
-  DELETE: path/to/removed/file — <reason>
-
-Proceed? [y/n]
-```
-
-**Modes:**
-- No flag: Show plan → Confirm → Execute
-- `--dry-run`: Show plan → STOP
-- `--yes`: Show plan → Execute immediately (no prompt)
-
----
-
 ## Git Safety
 
 **CLI:** `sdp guard activate <ws-id>` runs branch validation before build. Use it in setup (step 1). If guard reports wrong branch, STOP.
@@ -86,6 +55,36 @@ fi
 **NOTE:** Features MUST be implemented in feature branches. @oneshot creates the branch; @build only verifies.
 
 ---
+
+## Write Plan (F101)
+
+Before the TDD cycle (step 2 of EXECUTE THIS NOW), emit a write plan:
+
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. During the TDD cycle (step 2), enumerate source files, test files, and ws-verdict output.
+2. **Flags:**
+   - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
+   - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
+3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
+   ```json
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"build"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
+   ```
+   > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
+
+**Output format:**
+```
+WRITE PLAN for @build <ws-id>:
+  CREATE: path/to/new/file — <reason>
+  MODIFY: path/to/existing/file — <reason>
+  DELETE: path/to/removed/file — <reason>
+
+Proceed? [y/n]
+```
+
+**Modes:**
+- No flag: Show plan → Confirm → Execute
+- `--dry-run`: Show plan → STOP
+- `--yes`: Show plan → Execute immediately (no prompt)
 
 ## EXECUTE THIS NOW
 

--- a/prompts/skills/build/SKILL.md
+++ b/prompts/skills/build/SKILL.md
@@ -35,6 +35,37 @@ Continuation is the orchestrator's job (@oneshot / sdp orchestrate).
 
 ---
 
+## Write Plan (F101)
+
+Before the TDD cycle (step 2 of EXECUTE THIS NOW), emit a write plan:
+
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason.
+2. **Flags:**
+   - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
+   - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
+3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+   ```json
+   {"ts":"<ISO-8601>","type":"write_plan","skill":"build","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   ```
+
+**Output format:**
+```
+WRITE PLAN for @build <ws-id>:
+  CREATE: path/to/new/file — <reason>
+  MODIFY: path/to/existing/file — <reason>
+  DELETE: path/to/removed/file — <reason>
+
+Proceed? [y/n]
+```
+
+**Modes:**
+- No flag: Show plan → Confirm → Execute
+- `--dry-run`: Show plan → STOP
+- `--yes`: Show plan → Execute immediately (no prompt)
+
+---
+
 ## Git Safety
 
 **CLI:** `sdp guard activate <ws-id>` runs branch validation before build. Use it in setup (step 1). If guard reports wrong branch, STOP.

--- a/prompts/skills/deploy/SKILL.md
+++ b/prompts/skills/deploy/SKILL.md
@@ -43,10 +43,11 @@ Before modifying any file, emit a write plan:
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
-4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"ts":"<ISO-8601>","type":"write_plan","skill":"deploy","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"deploy"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
    ```
+   > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**
 ```
@@ -62,8 +63,6 @@ Proceed? [y/n]
 - No flag: Show plan → Confirm → Execute
 - `--dry-run`: Show plan → STOP
 - `--yes`: Show plan → Execute immediately (no prompt)
-
----
 
 ## Quick Reference
 

--- a/prompts/skills/deploy/SKILL.md
+++ b/prompts/skills/deploy/SKILL.md
@@ -38,15 +38,16 @@ When user invokes `@deploy F{XX}`:
 
 Before modifying any file, emit a write plan:
 
-1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason (PR, version bumps, CHANGELOG, release docs).
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason (CHANGELOG.md, release docs, version file).
 2. **Flags:**
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
 4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"deploy"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"deploy"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id if known>","workstream_id":"<ws-id if applicable>"}}
    ```
+   Include context fields only when the ID is known at plan time. Omit unavailable fields rather than inventing placeholders.
    > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**

--- a/prompts/skills/deploy/SKILL.md
+++ b/prompts/skills/deploy/SKILL.md
@@ -34,6 +34,37 @@ When user invokes `@deploy F{XX}`:
 
 ---
 
+## Write Plan (F101)
+
+Before modifying any file, emit a write plan:
+
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason (PR, version bumps, CHANGELOG, release docs).
+2. **Flags:**
+   - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
+   - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
+3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+   ```json
+   {"ts":"<ISO-8601>","type":"write_plan","skill":"deploy","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   ```
+
+**Output format:**
+```
+WRITE PLAN for @deploy <target>:
+  CREATE: path/to/new/file — <reason>
+  MODIFY: path/to/existing/file — <reason>
+  DELETE: path/to/removed/file — <reason>
+
+Proceed? [y/n]
+```
+
+**Modes:**
+- No flag: Show plan → Confirm → Execute
+- `--dry-run`: Show plan → STOP
+- `--yes`: Show plan → Execute immediately (no prompt)
+
+---
+
 ## Quick Reference
 
 | Mode | Action |

--- a/prompts/skills/design/SKILL.md
+++ b/prompts/skills/design/SKILL.md
@@ -107,8 +107,9 @@ Before modifying any file, emit a write plan covering workstream files, design d
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
 4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"design"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"design"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id if known>","workstream_id":"<ws-id if applicable>"}}
    ```
+   Include context fields only when the ID is known at plan time. Omit unavailable fields rather than inventing placeholders.
    > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**

--- a/prompts/skills/design/SKILL.md
+++ b/prompts/skills/design/SKILL.md
@@ -96,6 +96,35 @@ echo "Backlog:  $(ls docs/workstreams/backlog/*.md | wc -l)"
 
 Add new workstreams to the appropriate phase table in `docs/workstreams/INDEX.md`.
 
+## Write Plan (F101)
+
+Before modifying any file, emit a write plan covering workstream files, design docs, and INDEX.md:
+
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason.
+2. **Flags:**
+   - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
+   - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
+3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+   ```json
+   {"ts":"<ISO-8601>","type":"write_plan","skill":"design","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   ```
+
+**Output format:**
+```
+WRITE PLAN for @design <target>:
+  CREATE: path/to/new/file — <reason>
+  MODIFY: path/to/existing/file — <reason>
+  DELETE: path/to/removed/file — <reason>
+
+Proceed? [y/n]
+```
+
+**Modes:**
+- No flag: Show plan → Confirm → Execute
+- `--dry-run`: Show plan → STOP
+- `--yes`: Show plan → Execute immediately (no prompt)
+
 ## Modes
 
 | Mode | Blocks |

--- a/prompts/skills/design/SKILL.md
+++ b/prompts/skills/design/SKILL.md
@@ -100,15 +100,16 @@ Add new workstreams to the appropriate phase table in `docs/workstreams/INDEX.md
 
 Before modifying any file, emit a write plan covering workstream files, design docs, and INDEX.md:
 
-1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason.
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers workstream files, design docs, and INDEX.md updates.
 2. **Flags:**
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
-4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"ts":"<ISO-8601>","type":"write_plan","skill":"design","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"design"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
    ```
+   > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**
 ```

--- a/prompts/skills/feature/SKILL.md
+++ b/prompts/skills/feature/SKILL.md
@@ -159,6 +159,35 @@ Check discovery brief, idea spec, ux output, workstreams exist, direct execution
 
 User sees: feature description → workstreams created → ready to build. Workstream files, scope declarations, beads IDs are plumbing.
 
+## Write Plan (F101)
+
+Before creating workstream files and docs, emit a write plan:
+
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers workstream files in `docs/workstreams/backlog/`, discovery briefs, idea specs, UX outputs, and beads mappings.
+2. **Flags:**
+   - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
+   - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
+3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+   ```json
+   {"ts":"<ISO-8601>","type":"write_plan","skill":"feature","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   ```
+
+**Output format:**
+```
+WRITE PLAN for @feature <feature-id>:
+  CREATE: path/to/new/file — <reason>
+  MODIFY: path/to/existing/file — <reason>
+  DELETE: path/to/removed/file — <reason>
+
+Proceed? [y/n]
+```
+
+**Modes:**
+- No flag: Show plan → Confirm → Execute
+- `--dry-run`: Show plan → STOP
+- `--yes`: Show plan → Execute immediately (no prompt)
+
 ## See Also
 
 @discovery — Product discovery gate | @idea — Requirements | @ux — UX research | @design — Workstream planning | @build — Execute leaf workstream | @oneshot — Execute all ready leaf workstreams

--- a/prompts/skills/feature/SKILL.md
+++ b/prompts/skills/feature/SKILL.md
@@ -163,15 +163,16 @@ User sees: feature description → workstreams created → ready to build. Works
 
 Before creating workstream files and docs, emit a write plan:
 
-1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers workstream files in `docs/workstreams/backlog/`, discovery briefs, idea specs, UX outputs, and beads mappings.
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers workstream files, discovery briefs, idea specs, UX outputs, and beads mappings.
 2. **Flags:**
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
-4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"ts":"<ISO-8601>","type":"write_plan","skill":"feature","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"feature"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
    ```
+   > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**
 ```
@@ -183,10 +184,12 @@ WRITE PLAN for @feature <feature-id>:
 Proceed? [y/n]
 ```
 
-**Modes:**
+**Write-plan flags:**
 - No flag: Show plan → Confirm → Execute
 - `--dry-run`: Show plan → STOP
 - `--yes`: Show plan → Execute immediately (no prompt)
+
+> **Note:** `--dry-run` and `--yes` are orthogonal to skill mode flags (`--default`, `--quick`, `--auto`). They can be combined with any mode (e.g. `@feature "X" --quick --dry-run`).
 
 ## See Also
 

--- a/prompts/skills/feature/SKILL.md
+++ b/prompts/skills/feature/SKILL.md
@@ -170,8 +170,9 @@ Before creating workstream files and docs, emit a write plan:
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
 4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"feature"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"feature"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id if known>","workstream_id":"<ws-id if applicable>"}}
    ```
+   Include context fields only when the ID is known at plan time. Omit unavailable fields rather than inventing placeholders.
    > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**

--- a/prompts/skills/hotfix/SKILL.md
+++ b/prompts/skills/hotfix/SKILL.md
@@ -26,15 +26,16 @@ Emergency production fixes. Minimal changes, fast testing, merge to master with 
 
 Before modifying any file, emit a write plan:
 
-1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason (minimal fix files, tag, merge operations).
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason (fix files and version file).
 2. **Flags:**
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
 4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"hotfix"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"hotfix"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id if known>","workstream_id":"<ws-id if applicable>"}}
    ```
+   Include context fields only when the ID is known at plan time. Omit unavailable fields rather than inventing placeholders.
    > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**

--- a/prompts/skills/hotfix/SKILL.md
+++ b/prompts/skills/hotfix/SKILL.md
@@ -22,6 +22,35 @@ Emergency production fixes. Minimal changes, fast testing, merge to master with 
 5. **Tag** — `git tag -a v{VERSION} -m "Hotfix: {description}"`
 6. **Push** — `git push origin master --tags`
 
+## Write Plan (F101)
+
+Before modifying any file, emit a write plan:
+
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason (minimal fix files, tag, merge operations).
+2. **Flags:**
+   - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
+   - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
+3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+   ```json
+   {"ts":"<ISO-8601>","type":"write_plan","skill":"hotfix","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   ```
+
+**Output format:**
+```
+WRITE PLAN for @hotfix <target>:
+  CREATE: path/to/new/file — <reason>
+  MODIFY: path/to/existing/file — <reason>
+  DELETE: path/to/removed/file — <reason>
+
+Proceed? [y/n]
+```
+
+**Modes:**
+- No flag: Show plan → Confirm → Execute
+- `--dry-run`: Show plan → STOP
+- `--yes`: Show plan → Execute immediately (no prompt)
+
 ## Output
 
 Hotfix merged, tagged, pushed. Issue closed.

--- a/prompts/skills/hotfix/SKILL.md
+++ b/prompts/skills/hotfix/SKILL.md
@@ -31,10 +31,11 @@ Before modifying any file, emit a write plan:
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
-4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"ts":"<ISO-8601>","type":"write_plan","skill":"hotfix","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"hotfix"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
    ```
+   > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**
 ```

--- a/prompts/skills/oneshot/SKILL.md
+++ b/prompts/skills/oneshot/SKILL.md
@@ -21,19 +21,24 @@ Outer loop: `sdp-orchestrate` (or `sdp orchestrate` if available) drives phases.
 1. **Get next action** — Run `sdp-orchestrate --feature F{XX} --next-action`. Parse the JSON output (schema: `sdp/schema/next-action.schema.json`).
 2. **Execute phase and advance** — For `build`: run @build {ws_id}, commit, then `sdp-orchestrate --feature F{XX} --advance --result $(git rev-parse HEAD)`. For `review`: run @review F{XX}, fix P0/P1 until approved (max 3 iterations), then `sdp-orchestrate --feature F{XX} --advance`. **One advance per phase** — run `--advance` exactly once after build, exactly once after review. PR and CI run automatically. When action is `done`, output only: `CI GREEN - @oneshot complete`.
 
+## Post-compaction
+
+If context was compacted, read `.sdp/checkpoints/F{XX}.json` and `git checkout $(jq -r .branch .sdp/checkpoints/F{XX}.json)`. Resume from step 1.
+
 ## Write Plan (F101)
 
 Before the orchestration loop begins, emit a write plan covering all files touched across phases:
 
-1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers workstream verdicts, evidence files, checkpoints, and any source files modified by @build.
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers workstream verdicts, evidence files, checkpoints, and source files modified by @build.
 2. **Flags:**
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
-4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"ts":"<ISO-8601>","type":"write_plan","skill":"oneshot","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"oneshot"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
    ```
+   > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**
 ```
@@ -49,10 +54,6 @@ Proceed? [y/n]
 - No flag: Show plan → Confirm → Execute
 - `--dry-run`: Show plan → STOP
 - `--yes`: Show plan → Execute immediately (no prompt)
-
-## Post-compaction
-
-If context was compacted, read `.sdp/checkpoints/F{XX}.json` and `git checkout $(jq -r .branch .sdp/checkpoints/F{XX}.json)`. Resume from step 1.
 
 ## Claude Code
 

--- a/prompts/skills/oneshot/SKILL.md
+++ b/prompts/skills/oneshot/SKILL.md
@@ -21,6 +21,35 @@ Outer loop: `sdp-orchestrate` (or `sdp orchestrate` if available) drives phases.
 1. **Get next action** — Run `sdp-orchestrate --feature F{XX} --next-action`. Parse the JSON output (schema: `sdp/schema/next-action.schema.json`).
 2. **Execute phase and advance** — For `build`: run @build {ws_id}, commit, then `sdp-orchestrate --feature F{XX} --advance --result $(git rev-parse HEAD)`. For `review`: run @review F{XX}, fix P0/P1 until approved (max 3 iterations), then `sdp-orchestrate --feature F{XX} --advance`. **One advance per phase** — run `--advance` exactly once after build, exactly once after review. PR and CI run automatically. When action is `done`, output only: `CI GREEN - @oneshot complete`.
 
+## Write Plan (F101)
+
+Before the orchestration loop begins, emit a write plan covering all files touched across phases:
+
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers workstream verdicts, evidence files, checkpoints, and any source files modified by @build.
+2. **Flags:**
+   - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
+   - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
+3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+   ```json
+   {"ts":"<ISO-8601>","type":"write_plan","skill":"oneshot","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   ```
+
+**Output format:**
+```
+WRITE PLAN for @oneshot <feature-id>:
+  CREATE: path/to/new/file — <reason>
+  MODIFY: path/to/existing/file — <reason>
+  DELETE: path/to/removed/file — <reason>
+
+Proceed? [y/n]
+```
+
+**Modes:**
+- No flag: Show plan → Confirm → Execute
+- `--dry-run`: Show plan → STOP
+- `--yes`: Show plan → Execute immediately (no prompt)
+
 ## Post-compaction
 
 If context was compacted, read `.sdp/checkpoints/F{XX}.json` and `git checkout $(jq -r .branch .sdp/checkpoints/F{XX}.json)`. Resume from step 1.

--- a/prompts/skills/oneshot/SKILL.md
+++ b/prompts/skills/oneshot/SKILL.md
@@ -27,17 +27,18 @@ If context was compacted, read `.sdp/checkpoints/F{XX}.json` and `git checkout $
 
 ## Write Plan (F101)
 
-Before the orchestration loop begins, emit a write plan covering all files touched across phases:
+Before the orchestration loop begins, emit a write plan for orchestrator-owned artifacts. @build and @review emit their own detailed file plans when invoked:
 
-1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers workstream verdicts, evidence files, checkpoints, and source files modified by @build.
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers `.sdp/checkpoints`, `.sdp/evidence`, `.sdp/ws-verdicts`, and orchestrator state files. @build and @review handle their own file plans.
 2. **Flags:**
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
 4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"oneshot"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"oneshot"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id if known>","workstream_id":"<ws-id if applicable>"}}
    ```
+   Include context fields only when the ID is known at plan time. Omit unavailable fields rather than inventing placeholders.
    > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**

--- a/prompts/skills/review/SKILL.md
+++ b/prompts/skills/review/SKILL.md
@@ -89,31 +89,33 @@ For each finding: `bd create --silent --labels "review-finding,F{XX},round-1,{ro
 
 Before writing review output files (verdict, findings), emit a write plan:
 
-1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason.
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers review_verdict.json and any findings files created by the review process.
 2. **Flags:**
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
-4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"ts":"<ISO-8601>","type":"write_plan","skill":"review","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"review"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
    ```
+   > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**
 ```
 WRITE PLAN for @review <target>:
-  CREATE: .sdp/review_verdict.json — review verdict and synthesis
-  CREATE: .sdp/review/findings-*.json — per-reviewer finding details
+  CREATE: path/to/new/file — <reason>
+  MODIFY: path/to/existing/file — <reason>
+  DELETE: path/to/removed/file — <reason>
 
 Proceed? [y/n]
 ```
 
-**Modes:**
+**Write-plan flags:**
 - No flag: Show plan → Confirm → Execute
 - `--dry-run`: Show plan → STOP
 - `--yes`: Show plan → Execute immediately (no prompt)
 
----
+> **Note:** `--dry-run` and `--yes` are orthogonal to skill mode flags (`--full`, `--quick`). They can be combined with any mode (e.g. `@review F098 --quick --dry-run`).
 
 ## After All Complete — Synthesis Phase
 

--- a/prompts/skills/review/SKILL.md
+++ b/prompts/skills/review/SKILL.md
@@ -85,6 +85,34 @@ For each finding: `bd create --silent --labels "review-finding,F{XX},round-1,{ro
 
 **PromptOps expert:** Review prompts/skills, prompts/agents, prompts/commands. Check: language-agnostic, no phantom CLI, no handoff lists, skill size ≤200 LOC. Labels: `review-finding,F{XX},round-1,promptops`. Output `checks` array per schema/review-verdict.schema.json.
 
+## Write Plan (F101)
+
+Before writing review output files (verdict, findings), emit a write plan:
+
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason.
+2. **Flags:**
+   - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
+   - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
+3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+   ```json
+   {"ts":"<ISO-8601>","type":"write_plan","skill":"review","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   ```
+
+**Output format:**
+```
+WRITE PLAN for @review <target>:
+  CREATE: .sdp/review_verdict.json — review verdict and synthesis
+  CREATE: .sdp/review/findings-*.json — per-reviewer finding details
+
+Proceed? [y/n]
+```
+
+**Modes:**
+- No flag: Show plan → Confirm → Execute
+- `--dry-run`: Show plan → STOP
+- `--yes`: Show plan → Execute immediately (no prompt)
+
 ---
 
 ## After All Complete — Synthesis Phase

--- a/prompts/skills/review/SKILL.md
+++ b/prompts/skills/review/SKILL.md
@@ -89,15 +89,16 @@ For each finding: `bd create --silent --labels "review-finding,F{XX},round-1,{ro
 
 Before writing review output files (verdict, findings), emit a write plan:
 
-1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers review_verdict.json and any findings files created by the review process.
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers review_verdict.json and any findings files created during review.
 2. **Flags:**
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
 4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"review"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"review"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id if known>","workstream_id":"<ws-id if applicable>"}}
    ```
+   Include context fields only when the ID is known at plan time. Omit unavailable fields rather than inventing placeholders.
    > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**

--- a/prompts/skills/vision/SKILL.md
+++ b/prompts/skills/vision/SKILL.md
@@ -14,6 +14,35 @@ Transform project ideas into vision, PRD, and roadmap.
 3. **Generate artifacts** — PRODUCT_VISION.md, docs/prd/PRD.md (or docs/PROJECT_MAP.md), docs/roadmap/ROADMAP.md
 4. **Extract features** — docs/drafts/feature-{slug}.md for P0/P1
 
+## Write Plan (F101)
+
+Before modifying any file, emit a write plan covering PRODUCT_VISION.md, PRD.md, ROADMAP.md, and feature drafts:
+
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason.
+2. **Flags:**
+   - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
+   - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
+3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+   ```json
+   {"ts":"<ISO-8601>","type":"write_plan","skill":"vision","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   ```
+
+**Output format:**
+```
+WRITE PLAN for @vision <target>:
+  CREATE: path/to/new/file — <reason>
+  MODIFY: path/to/existing/file — <reason>
+  DELETE: path/to/removed/file — <reason>
+
+Proceed? [y/n]
+```
+
+**Modes:**
+- No flag: Show plan → Confirm → Execute
+- `--dry-run`: Show plan → STOP
+- `--yes`: Show plan → Execute immediately (no prompt)
+
 ## PRD Mode
 
 Detect project type (service/library/cli) from structure. Scaffold PRD with type-appropriate sections. Generate diagrams from @prd annotations in code. Validate section limits. `@vision "name" --update` regenerates diagrams from annotations.

--- a/prompts/skills/vision/SKILL.md
+++ b/prompts/skills/vision/SKILL.md
@@ -25,8 +25,9 @@ Before modifying any file, emit a write plan covering PRODUCT_VISION.md, PRD.md,
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
 4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"vision"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"vision"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id if known>","workstream_id":"<ws-id if applicable>"}}
    ```
+   Include context fields only when the ID is known at plan time. Omit unavailable fields rather than inventing placeholders.
    > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**

--- a/prompts/skills/vision/SKILL.md
+++ b/prompts/skills/vision/SKILL.md
@@ -18,15 +18,16 @@ Transform project ideas into vision, PRD, and roadmap.
 
 Before modifying any file, emit a write plan covering PRODUCT_VISION.md, PRD.md, ROADMAP.md, and feature drafts:
 
-1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason.
+1. **Enumerate** — List every file the skill will CREATE / MODIFY / DELETE with a one-line reason. Covers PRODUCT_VISION.md, PRD.md, ROADMAP.md, and feature drafts.
 2. **Flags:**
    - `--dry-run` — Emit write plan only. Do NOT create, modify, or delete any file.
    - `--yes` — Skip confirmation prompt. Execute immediately. Intended for CI/non-interactive.
 3. **Confirm** — Present the plan to the user and wait for explicit approval (unless `--yes`).
-4. **Log** — Append write plan event to `.sdp/log/events.jsonl`:
+4. **Log** — Append write plan event to `.sdp/log/events.jsonl` (**sanitize file paths** before logging: strip newlines, ensure valid JSON escaping):
    ```json
-   {"ts":"<ISO-8601>","type":"write_plan","skill":"vision","ws_id":"<ws-id>","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]}
+   {"spec_version":"v1.0","event_id":"<uuid>","timestamp":"<ISO-8601>","source":{"system":"sdp-lab","component":"vision"},"event_type":"decision.made","payload":{"decision_type":"write_plan","plan":[{"path":"...","action":"CREATE|MODIFY|DELETE","reason":"..."}]},"context":{"feature_id":"<F-id>","workstream_id":"<ws-id>"}}
    ```
+   > **Note:** Phase 1 uses prompt-level write boundaries (CLI out of scope). Aligns with `sdp/schema/contracts/orchestration-event.schema.json` via `event_type: "decision.made"`. Phase 2 CLI will emit natively.
 
 **Output format:**
 ```


### PR DESCRIPTION
## Summary
- add a Write Plan section to 9 stateful skills
- require file enumeration before execution: CREATE / MODIFY / DELETE with reason
- document `--dry-run` and `--yes` behavior for non-interactive runs
- log prompt-level write plan decisions to `.sdp/log/events.jsonl`

## Verification
- `git diff --check origin/main..HEAD`
- `go test ./...`
